### PR TITLE
fix: include Chinese fonts in font stacks for Windows

### DIFF
--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -24,8 +24,8 @@
 
 /* Warm paper + orange accent design system (from design.html) */
 :root {
-  --font-inter: "Inter";
-  --font-noto-mono: "Noto Sans Mono";
+  --font-inter: "Inter", "Microsoft YaHei", "PingFang SC", "Noto Sans SC", system-ui, sans-serif;
+  --font-noto-mono: "Noto Sans Mono", "PingFang SC", "Microsoft YaHei", ui-monospace, monospace;
   --bg: #f7f6f3;
   --bg-panel: #fcfbf9;
   --bg-hover: #f0eeea;
@@ -224,7 +224,7 @@ html.dark ::-webkit-scrollbar-thumb {
     var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei",
     "Noto Sans SC", sans-serif;
   --font-mono:
-    var(--font-noto-mono), "JetBrains Mono", "Fira Code", "Consolas", ui-monospace, "PingFang SC", "Microsoft YaHei",
+    var(--font-noto-mono), "JetBrains Mono", "Fira Code", "Consolas", "PingFang SC", "Microsoft YaHei", ui-monospace,
     monospace;
 }
 


### PR DESCRIPTION
Windows 下中文字体栈修正：为 --font-sans 补充 PingFang SC / Microsoft YaHei
fallback，修复中文界面在 Windows 上的字体渲染。