### PR TITLE
feat: use app icon and bigger title in chat header and sidebar

### DIFF
--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -25,6 +25,7 @@ import { useDragDrop } from "@/hooks/useDragDrop";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import type { SessionStatsInfo } from "@/lib/pi-types";
 import { useI18n } from "@/i18n";
+import appIconUrl from "../../../build/icon.png";
 
 interface Props {
   session: SessionInfo | null;
@@ -571,7 +572,6 @@ export function ChatWindow({
                 justifyContent: "center",
                 marginLeft: 16,
                 marginRight: 52,
-                fontFamily: "var(--font-mono)",
               }}
             >
               <div
@@ -582,29 +582,21 @@ export function ChatWindow({
                   lineHeight: 1.4,
                 }}
               >
-                <span
+                <img
+                  src={appIconUrl}
+                  alt=""
+                  aria-hidden="true"
                   style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: 6,
-                    background: "var(--text)",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    fontSize: 14,
-                    fontWeight: 700,
-                    color: "var(--accent)",
+                    width: 36,
+                    height: 36,
+                    objectFit: "contain",
                     flexShrink: 0,
                   }}
-                >
-                  $
-                </span>
+                />
                 <span
                   style={{
-                    fontSize: 22,
+                    fontSize: 26,
                     color: "var(--text)",
-                    fontWeight: 700,
-                    letterSpacing: "-0.2px",
                     flexShrink: 0,
                     whiteSpace: "nowrap",
                   }}

--- a/src/renderer/components/SessionSidebar.tsx
+++ b/src/renderer/components/SessionSidebar.tsx
@@ -13,6 +13,7 @@ import {
   type SessionDateGroup,
 } from "@/lib/session-list";
 import { applySessionChangedEvent } from "@/lib/session-sidebar-state";
+import appIconUrl from "../../../build/icon.png";
 
 interface Props {
   selectedSessionId: string | null;
@@ -312,26 +313,18 @@ function PiAgentTitle() {
         minWidth: "6ch",
       }}
     >
-      <span
+      <img
+        src={appIconUrl}
+        alt=""
+        aria-hidden="true"
         style={{
-          width: 22,
-          height: 22,
-          borderRadius: 5,
-          background: "var(--text)",
-          display: "inline-flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontFamily: "var(--font-mono)",
-          fontSize: 12,
-          color: "var(--accent)",
-          fontWeight: 700,
+          width: 28,
+          height: 28,
+          objectFit: "contain",
           flexShrink: 0,
         }}
-        aria-hidden="true"
-      >
-        $
-      </span>
-      <span style={{ fontWeight: 700, fontSize: 14, letterSpacing: "-0.2px", fontFamily: "var(--font-mono)" }}>
+      />
+      <span style={{ fontWeight: 700, fontSize: 16, letterSpacing: "-0.2px", fontFamily: "var(--font-mono)" }}>
         {display}
       </span>
     </button>


### PR DESCRIPTION
Replace the placeholder "$" glyph badges with the real app icon (build/icon.png) in the chat header and session sidebar, and bump the adjacent title sizes.