### PR TITLE
fix(chat): release scroll-follow magnet on explicit upward wheel/keys

### DIFF
--- a/src/renderer/hooks/useAgentSession.ts
+++ b/src/renderer/hooks/useAgentSession.ts
@@ -1843,6 +1843,20 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     const container = scrollContainerRef.current;
     if (container) lastScrollTopRef.current = container.scrollTop;
     userScrollIntentUntilRef.current = Date.now() + USER_SCROLL_INTENT_MS;
+
+    // Explicit upward gestures release the follow magnet immediately. Waiting
+    // for scroll-position deltas loses during streaming: every follow frame
+    // refreshes the programmatic-scroll guard, so a small user scroll-up gets
+    // swallowed and the view snaps back down.
+    const isUpwardGesture =
+      (event instanceof WheelEvent && event.deltaY < 0 && !event.ctrlKey) || // ctrl+wheel = pinch-zoom, not scroll
+      (event instanceof KeyboardEvent && (event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home"));
+    if (isUpwardGesture && Date.now() >= sessionChangeIgnoreScrollUntilRef.current) {
+      completionScrollAllowedRef.current = false;
+      externalTurnAutoFollowRef.current = false;
+      autoFollowMagnetRef.current = false;
+      setScrollMagnetEngaged(false);
+    }
   }, []);
 
   const handleScrollPositionChange = useCallback(() => {


### PR DESCRIPTION
## Summary

Follow-up to #11: the scroll-follow magnet could not be released by a small manual scroll during active streaming.

**Root cause:** every auto-follow frame refreshes the programmatic-scroll guard (~700 ms window). A small user scroll-up landed inside that window and was discarded as "our own scroll", then the next follow frame snapped the view back down.

**Fix:** explicit upward gestures release the magnet immediately at the input-event level — wheel-up (`deltaY < 0`, excluding Ctrl+wheel pinch-zoom) and ArrowUp/PageUp/Home — bypassing the delta-based detection that loses the race against streaming follow frames. Scrolling back to the bottom re-engages the magnet, as before. Session switches are still guarded (content reload doesn't disengage).

## Changes

`src/renderer/hooks/useAgentSession.ts` — `markUserScrollIntent` now disengages the follow magnet on explicit upward input gestures.

## Test

- ✅ typecheck / ESLint
- ✅ scroll-policy unit tests pass
- ✅ verified live: during a long streaming answer, a one-paragraph wheel-up disengages the magnet; the scroll badge appears and the view stays put instead of snapping back down
