### PR TITLE
feat(chat): remember thinking-block expand state; hide empty text bubbles

### DIFF
--- a/src/renderer/components/MessageView.tsx
+++ b/src/renderer/components/MessageView.tsx
@@ -6,6 +6,7 @@ import {
   getAssistantFailureDetail,
   hasRenderableAssistantMessage,
   isAssistantFailure,
+  isEmptyTextBlock,
   isEmptyThinkingBlock,
 } from "@/lib/message-display";
 import { getUserBubbleStyle } from "@/lib/channel-message-style";
@@ -546,7 +547,7 @@ function AssistantMessageView({
   const time = showTimestamp ? formatTime(message.timestamp) : null;
   const blockItems = (message.content ?? [])
     .map((block, originalIndex) => ({ block, originalIndex }))
-    .filter(({ block }) => !isEmptyThinkingBlock(block, { isStreaming }));
+    .filter(({ block }) => !isEmptyThinkingBlock(block, { isStreaming }) && !isEmptyTextBlock(block, { isStreaming }));
   const blocks = blockItems.map(({ block }) => block);
   const [hovered, setHovered] = useState(false);
   const { copied, copy } = useCopyFeedback();
@@ -916,9 +917,32 @@ function TextBlock({
   );
 }
 
+// Expanded/collapsed state survives chat switches (component remounts wipe
+// useState; this module state lives for the app's lifetime).
+// Per-content override + a default from the user's last toggle: expand one
+// block and new thinking blocks start expanded; collapse → new start collapsed.
+// Bounded FIFO: keys are full thinking texts (KBs each), so cap the map.
+const THINKING_STATE_LIMIT = 200;
+const thinkingExpandedByContent = new Map<string, boolean>();
+let thinkingDefaultExpanded = false;
+
 function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?: number }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(
+    () => thinkingExpandedByContent.get(block.thinking) ?? thinkingDefaultExpanded,
+  );
   const { t } = useI18n();
+  const toggleExpanded = () =>
+    setExpanded((prev) => {
+      const next = !prev;
+      thinkingExpandedByContent.delete(block.thinking); // refresh position for FIFO order
+      thinkingExpandedByContent.set(block.thinking, next);
+      if (thinkingExpandedByContent.size > THINKING_STATE_LIMIT) {
+        const oldest = thinkingExpandedByContent.keys().next().value;
+        if (oldest !== undefined) thinkingExpandedByContent.delete(oldest);
+      }
+      thinkingDefaultExpanded = next;
+      return next;
+    });
   return (
     <div
       style={{
@@ -930,7 +954,7 @@ function ThinkingBlock({ block, duration }: { block: ThinkingContent; duration?:
       }}
     >
       <button
-        onClick={() => setExpanded((v) => !v)}
+        onClick={toggleExpanded}
         style={{
           display: "flex",
           alignItems: "center",

--- a/src/shared/message-display.ts
+++ b/src/shared/message-display.ts
@@ -1,4 +1,4 @@
-import type { AssistantContentBlock, AssistantMessage, ThinkingContent, ToolCallContent } from "./types";
+import type { AssistantContentBlock, AssistantMessage, TextContent, ThinkingContent, ToolCallContent } from "./types";
 
 interface DisplayOptions {
   isStreaming?: boolean;
@@ -21,11 +21,18 @@ export function isEmptyThinkingBlock(
   return block.type === "thinking" && !options.isStreaming && block.thinking.trim() === "";
 }
 
+/** Empty text segments render as pointless blank bubbles (e.g. between thinking and tool calls). */
+export function isEmptyTextBlock(block: AssistantContentBlock, options: DisplayOptions = {}): block is TextContent {
+  return block.type === "text" && !options.isStreaming && block.text.trim() === "";
+}
+
 export function getDisplayableAssistantBlocks(
   message: AssistantMessage,
   options: DisplayOptions = {},
 ): AssistantContentBlock[] {
-  return (message.content ?? []).filter((block) => !isEmptyThinkingBlock(block, options));
+  return (message.content ?? []).filter(
+    (block) => !isEmptyThinkingBlock(block, options) && !isEmptyTextBlock(block, options),
+  );
 }
 
 export function hasRenderableAssistantMessage(message: AssistantMessage, options: DisplayOptions = {}): boolean {


### PR DESCRIPTION
## Summary

Small quality-of-life improvements for thinking blocks.

- **Expanded state persists across chat switches.** The component's local `useState` was wiped on unmount, so returning to a chat showed every thinking block collapsed again. State now lives in a module-level per-content map (bounded FIFO, 200 entries), and the user's last toggle becomes the default for new thinking blocks: expand one → new ones start expanded; collapse → they start collapsed.
- **Empty text segments no longer render as blank bubbles.** Some models emit empty text blocks between thinking and tool calls; they are filtered out when not streaming (during streaming they stay — that's live output starting).

## Changes

- `src/renderer/components/MessageView.tsx` — persistent thinking expand state; empty-text filter wired into block list
- `src/shared/message-display.ts` — new `isEmptyTextBlock` helper, included in `getDisplayableAssistantBlocks`

## Test

- ✅ typecheck / ESLint
- ✅ verified live: expand thinking → switch chat → return → still expanded; new runs follow the last toggle; no blank bubbles after thinking
