### PR TITLE
feat(chat): attach any file, autolink file paths, rich file context menu

### DIFF
--- a/src/contract/desktop.ts
+++ b/src/contract/desktop.ts
@@ -110,6 +110,10 @@ export interface PiBridge {
   requestHostPort: () => void;
   openExternal: (url: string) => Promise<void>;
   showItemInFolder: (fsPath: string) => Promise<void>;
+  /** Show the app's rich file context menu for a resolved path. */
+  showFileContextMenu: (fsPath: string) => Promise<void>;
+  /** Resolve the absolute filesystem path for a dropped/injected File object. */
+  getPathForFile?: (file: File) => string | null;
   selectDirectory: () => Promise<string | null>;
   setChannelCredential: (payload: ChannelCredentialWrite) => Promise<void>;
   saveFile: (opts: SaveTextFileOptions) => Promise<string | null>;

--- a/src/main/file-associations.ts
+++ b/src/main/file-associations.ts
@@ -1,0 +1,311 @@
+import { execFile, spawn } from "node:child_process";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Windows file association resolver.
+// Reads the registry (via reg.exe) to find:
+//   - the default app for a file type ("Open in VS Code")
+//   - the system "Open with" handler list for that extension
+// Shell tools (Terminal, Git Bash, WSL, PowerShell...) are excluded — those
+// are not editors. Everything is cached per extension for 5 minutes.
+// ---------------------------------------------------------------------------
+
+export interface FileOpenHandler {
+  name: string;
+  command: string;
+}
+
+export interface FileAssociations {
+  defaultApp: FileOpenHandler | null;
+  handlers: FileOpenHandler[];
+}
+
+const SHELL_BLOCKLIST = new Set([
+  "cmd.exe",
+  "powershell.exe",
+  "pwsh.exe",
+  "wt.exe",
+  "windowsterminal.exe",
+  "wsl.exe",
+  "bash.exe",
+  "mintty.exe",
+  "git-bash.exe",
+  "git-cmd.exe",
+  "conhost.exe",
+  "explorer.exe",
+  "rundll32.exe",
+  "dllhost.exe",
+  "mshta.exe",
+  "cscript.exe",
+  "wscript.exe",
+]);
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, { at: number; result: FileAssociations }>();
+
+function regQuery(key: string): Promise<Map<string, string>> {
+  return new Promise((resolve) => {
+    execFile("reg.exe", ["query", key], { timeout: 5000, windowsHide: true }, (_err, stdout) => {
+      resolve(parseRegOutput(String(stdout ?? "")));
+    });
+  });
+}
+
+function parseRegOutput(out: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const line of out.split(/\r?\n/)) {
+    // "    <name>    REG_SZ    <data>" — default value shows as "(Default)".
+    const m = line.match(/^\s+(\(Default\)|\S+)\s+REG_\w+(?:\s+(.*))?$/);
+    if (m) map.set(m[1], (m[2] ?? "").trim());
+  }
+  return map;
+}
+
+interface ResolvedHandler extends FileOpenHandler {
+  exe: string | null;
+}
+
+function extractExe(command: string): string | null {
+  const quoted = command.match(/^"([^"]+\.exe)"/i);
+  if (quoted) return quoted[1];
+  const bare = command.match(/([^\s]+\.exe)/i);
+  return bare ? bare[1] : null;
+}
+
+function prettyExeName(exePath: string): string {
+  return path.basename(exePath).replace(/\.exe$/i, "");
+}
+
+/**
+ * Pretty display names from the exe's own version resource (FileDescription),
+ * e.g. "Notepad++" / "Google Chrome" / "Visual Studio Code". Many apps do not
+ * register FriendlyAppName, and the raw exe basename looks bad ("chrome").
+ * One PowerShell call for the whole batch; results are keyed by exe path.
+ */
+async function readFileDescriptions(exes: string[]): Promise<Map<string, string>> {
+  const unique = [...new Set(exes.filter(Boolean))];
+  const map = new Map<string, string>();
+  if (unique.length === 0) return map;
+  const list = unique.map((p) => `'${p.replace(/'/g, "''")}'`).join(",");
+  const script =
+    "[Console]::OutputEncoding=[Text.Encoding]::UTF8;" +
+    `@(${list}) | ForEach-Object { try { $v = (Get-Item -LiteralPath $_).VersionInfo.FileDescription;` +
+    " if ($v) { Write-Output ($_ + [char]31 + $v) } } catch {} }";
+  try {
+    const { spawn } = await import("node:child_process");
+    const out = await new Promise<string>((resolve) => {
+      const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script]);
+      let buf = "";
+      child.stdout.on("data", (d: Buffer) => (buf += d.toString("utf8")));
+      child.on("close", () => resolve(buf));
+      child.on("error", () => resolve(""));
+    });
+    for (const line of out.split(/\r?\n/)) {
+      const i = line.indexOf("\x1f");
+      if (i > 0) map.set(line.slice(0, i), line.slice(i + 1).trim());
+    }
+  } catch {
+    /* PowerShell unavailable — keep basename fallback */
+  }
+  return map;
+}
+
+/** Upgrade bare exe-basename names ("chrome") to FileDescription ("Google Chrome"). */
+async function applyPrettyNames(handlers: (ResolvedHandler | FileOpenHandler)[]): Promise<void> {
+  const exes = handlers.map((h) => ("exe" in h ? h.exe : null)).filter((e): e is string => Boolean(e));
+  if (exes.length === 0) return;
+  const descriptions = await readFileDescriptions(exes);
+  if (descriptions.size === 0) return;
+  for (const h of handlers) {
+    if (!("exe" in h) || !h.exe) continue;
+    const description = descriptions.get(h.exe);
+    // Only replace names that fell back to the raw basename.
+    if (description && h.name === prettyExeName(h.exe)) h.name = description;
+  }
+}
+
+function cleanName(raw: string | undefined): string {
+  if (!raw) return "";
+  // "@shell32.dll,-123" / "@{Package...}" style resource refs can't be resolved cheaply.
+  if (raw.startsWith("@")) return "";
+  return raw;
+}
+
+async function resolveProgId(progId: string): Promise<ResolvedHandler | null> {
+  try {
+    // CurVer redirect (e.g. "txtfile" -> versioned id), follow one level.
+    const curver = await regQuery(`HKCR\\${progId}\\CurVer`);
+    const id = curver.get("(Default)") || progId;
+    const [rootVals, cmdVals] = await Promise.all([
+      regQuery(`HKCR\\${id}`),
+      regQuery(`HKCR\\${id}\\shell\\open\\command`),
+    ]);
+    const command = cmdVals.get("(Default)");
+    if (!command) return null;
+    const exe = extractExe(command);
+    const name =
+      cleanName(rootVals.get("FriendlyAppName")) ||
+      cleanName(rootVals.get("ApplicationName")) ||
+      (exe ? prettyExeName(exe) : id);
+    return { name, command, exe };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveExeApp(exeName: string): Promise<ResolvedHandler | null> {
+  try {
+    const [appCmd, appRoot] = await Promise.all([
+      regQuery(`HKCR\\Applications\\${exeName}\\shell\\open\\command`),
+      regQuery(`HKCR\\Applications\\${exeName}`),
+    ]);
+    let command = appCmd.get("(Default)") || "";
+    if (!command) {
+      // App Paths fallback: full exe path, assume "%1" arg convention.
+      for (const root of [
+        "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+        "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths",
+      ]) {
+        const vals = await regQuery(`${root}\\${exeName}`);
+        const exePath = vals.get("(Default)");
+        if (exePath && /\.exe$/i.test(exePath)) {
+          command = `"${exePath}" "%1"`;
+          break;
+        }
+      }
+    }
+    if (!command) return null;
+    const exe = extractExe(command);
+    const name =
+      cleanName(appRoot.get("FriendlyAppName")) || (exe ? prettyExeName(exe) : exeName.replace(/\.exe$/i, ""));
+    return { name, command, exe };
+  } catch {
+    return null;
+  }
+}
+
+function isBlocked(handler: ResolvedHandler): boolean {
+  const base = handler.exe ? path.basename(handler.exe).toLowerCase() : "";
+  return base !== "" && SHELL_BLOCKLIST.has(base);
+}
+
+function sameHandler(a: ResolvedHandler | FileOpenHandler, b: ResolvedHandler | FileOpenHandler): boolean {
+  const keyOf = (h: ResolvedHandler | FileOpenHandler) => ("exe" in h && h.exe ? h.exe : h.command).toLowerCase();
+  return keyOf(a) === keyOf(b);
+}
+
+async function computeAssociations(ext: string): Promise<FileAssociations> {
+  const fileExtsKey = `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\${ext}`;
+  const [userChoice, hkcrExt, crProgids, cuProgids, openWithList] = await Promise.all([
+    regQuery(`${fileExtsKey}\\UserChoice`),
+    regQuery(`HKCR\\${ext}`),
+    regQuery(`HKCR\\${ext}\\OpenWithProgids`),
+    regQuery(`${fileExtsKey}\\OpenWithProgids`),
+    regQuery(`${fileExtsKey}\\OpenWithList`),
+  ]);
+
+  const defaultProgId = userChoice.get("ProgId") || hkcrExt.get("(Default)") || null;
+
+  const progIds = new Set<string>();
+  for (const map of [crProgids, cuProgids]) {
+    for (const key of map.keys()) {
+      if (key !== "(Default)") progIds.add(key);
+    }
+  }
+  const exeNames: string[] = [];
+  for (const [key, value] of openWithList) {
+    if (key === "(Default)" || key.toLowerCase() === "mrulist" || !value) continue;
+    exeNames.push(value);
+  }
+
+  const resolvedProgIds = await Promise.all([...progIds].map(resolveProgId));
+  const resolvedExes = await Promise.all(exeNames.map(resolveExeApp));
+  const all = [...resolvedProgIds, ...resolvedExes].filter((h): h is ResolvedHandler => h !== null);
+  // Raw exe basenames ("chrome") get replaced with FileDescription ("Google Chrome").
+  await applyPrettyNames(all);
+
+  // Default app for "Open in X" — the per-user choice wins over the system default.
+  let defaultApp: ResolvedHandler | null = null;
+  if (defaultProgId) {
+    defaultApp = /^Applications\\/i.test(defaultProgId)
+      ? await resolveExeApp(defaultProgId.replace(/^Applications\\/i, ""))
+      : await resolveProgId(defaultProgId);
+  }
+  if (defaultApp && isBlocked(defaultApp)) defaultApp = null;
+  // Self-executing types (.exe, .bat...) resolve to a bare "%1" command —
+  // that's not an editor, "Open file" already covers it.
+  if (defaultApp && /^"?%1"?/.test(defaultApp.command.trim())) defaultApp = null;
+
+  // Handlers for "Open with": dedupe by exe/command, drop shells and the default
+  // (it already has its own menu entry).
+  const seen = new Set<string>();
+  const handlers: FileOpenHandler[] = [];
+  for (const handler of all) {
+    if (isBlocked(handler)) continue;
+    if (defaultApp && sameHandler(handler, defaultApp)) continue;
+    const key = (handler.exe || handler.command).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    handlers.push({ name: handler.name, command: handler.command });
+  }
+
+  return {
+    defaultApp: defaultApp ? { name: defaultApp.name, command: defaultApp.command } : null,
+    handlers: handlers.slice(0, 10),
+  };
+}
+
+export async function getFileAssociations(filePath: string): Promise<FileAssociations> {
+  if (process.platform !== "win32") return { defaultApp: null, handlers: [] };
+  const ext = path.extname(filePath).toLowerCase();
+  if (!ext) return { defaultApp: null, handlers: [] };
+  const hit = cache.get(ext);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.result;
+  const result = await computeAssociations(ext);
+  if (cache.size > 64) cache.clear();
+  cache.set(ext, { at: Date.now(), result });
+  return result;
+}
+
+/** Split a trusted registry command line into tokens (quotes stripped). */
+function tokenizeCommandLine(cmd: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cmd))) tokens.push(m[1] ?? m[2]);
+  return tokens;
+}
+
+/** Run a registry open-command against a file: expands env vars, substitutes %1 / %*.
+ *  Uses spawn without a shell so %VAR%-like sequences inside the file name survive. */
+export function runOpenWith(command: string, targetPath: string): void {
+  const expanded = command.replace(/%([A-Za-z0-9_]+)%/g, (match, name: string) => process.env[name] ?? match);
+  const tokens = tokenizeCommandLine(expanded);
+  if (!tokens.length) return;
+  const exe = tokens[0];
+  let substituted = false;
+  const args = tokens.slice(1).map((token) => {
+    if (/%1/i.test(token)) {
+      substituted = true;
+      return token.replace(/%1/gi, targetPath);
+    }
+    if (token === "%*") {
+      substituted = true;
+      return targetPath;
+    }
+    return token;
+  });
+  if (!substituted) args.push(targetPath);
+  try {
+    const child = spawn(exe, args, { windowsHide: true, detached: true, stdio: "ignore" });
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+    /* handler exe missing */
+  }
+}
+
+/** Native Windows "Open with…" dialog. */
+export function openWithDialog(targetPath: string): void {
+  execFile("rundll32.exe", ["shell32.dll,OpenAs_RunDLL", targetPath], { windowsHide: true }, () => {});
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme, Notification, shell } from "electron";
-import type { IpcMainEvent, IpcMainInvokeEvent } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, Notification, shell } from "electron";
+import type { ContextMenuParams, IpcMainEvent, IpcMainInvokeEvent } from "electron";
 import type {
   ChannelCredentialWrite,
   DesktopUpdateState,
@@ -9,6 +9,7 @@ import type {
 import { exportDiagnostics } from "./diagnostics";
 import type { HostManager } from "./host-manager";
 import { appendMainLog, getMainLogPath } from "./logger";
+import { buildFileContextMenu } from "./window";
 import { createHtmlPreviewUrl, releaseHtmlPreviewUrl } from "./protocol";
 import { loadUiState, saveUiState } from "./window-state";
 import path from "node:path";
@@ -182,6 +183,31 @@ export function installDesktopIpc(options: DesktopIpcOptions): void {
 
   trustedHandle("desktop:show-item-in-folder", async (_event, fsPath: string) => {
     if (typeof fsPath === "string") shell.showItemInFolder(fsPath);
+  });
+
+  // Rich file context menu, built in main from a real path (Chromium does not
+  // reliably fill params.linkURL for file: links in Electron 43, so the renderer
+  // resolves the path itself and hands it over here).
+  trustedHandle("desktop:file-context-menu", async (event, fsPath: unknown) => {
+    // Renderer supplies the path (Chromium drops file: linkURL); require an
+    // absolute path so the menu actions (open/copy) stay on real filesystem targets.
+    if (typeof fsPath !== "string" || !path.isAbsolute(fsPath)) return;
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+    try {
+      const template = await buildFileContextMenu(
+        win,
+        fsPath,
+        {
+          selectionText: "",
+          isEditable: false,
+        } as ContextMenuParams,
+        { withTextItems: false },
+      );
+      if (!win.isDestroyed()) Menu.buildFromTemplate(template).popup({ window: win });
+    } catch {
+      /* menu is best-effort */
+    }
   });
 
   trustedHandle("desktop:select-directory", async (event) => {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,5 +1,19 @@
-import { BrowserWindow, nativeTheme, screen, shell } from "electron";
+import { existsSync } from "node:fs";
+import { copyFile, open, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import {
+  BrowserWindow,
+  clipboard,
+  dialog,
+  Menu,
+  MenuItemConstructorOptions,
+  nativeTheme,
+  screen,
+  shell,
+} from "electron";
+import type { ContextMenuParams } from "electron";
 import { appendMainLog } from "./logger";
+import { getFileAssociations, openWithDialog, runOpenWith } from "./file-associations";
 import { resolvePreloadPath, resolveRendererEntry } from "./host-manager";
 import { releaseHtmlPreviewsForOwner } from "./protocol";
 import { createLoadFailurePage, createRendererCrashPage, RENDERER_CRASH_RETRY_URL } from "./window-load-failure";
@@ -25,6 +39,199 @@ export type CreateMainWindowOptions = {
   onRendererUnavailable?: (reason: string) => void;
   onConsoleError?: (message: string) => void;
 };
+
+function urlToWindowsPath(linkUrl: string | undefined): string | null {
+  if (!linkUrl) return null;
+  try {
+    const url = new URL(linkUrl);
+    if (url.protocol !== "file:") return null;
+    const pathname = decodeURIComponent(url.pathname);
+    // file://server/share -> //server/share (UNC); file:///C:/... -> C:/...
+    if (url.host) return `//${url.host}${pathname}`;
+    return /^\/[a-zA-Z]:\//.test(pathname) ? pathname.slice(1) : pathname;
+  } catch {
+    return null;
+  }
+}
+
+function appendTextItems(template: MenuItemConstructorOptions[], params: ContextMenuParams, win: BrowserWindow) {
+  let added = false;
+  if (params.isEditable) {
+    if (params.editFlags.canCut) {
+      template.push({ label: "Cut", role: "cut" });
+      added = true;
+    }
+    if (params.editFlags.canCopy) {
+      template.push({ label: "Copy", role: "copy" });
+      added = true;
+    }
+    if (params.editFlags.canPaste) {
+      template.push({ label: "Paste", role: "paste" });
+      added = true;
+    }
+  } else if (params.selectionText.trim().length > 0) {
+    template.push(
+      {
+        label: `Copy`,
+        click: () => clipboard.writeText(params.selectionText),
+      },
+      {
+        label: `Search Google for "${params.selectionText.trim().slice(0, 42).replace(/"/g, "'")}"`,
+        click: () =>
+          void shell.openExternal(`https://www.google.com/search?q=${encodeURIComponent(params.selectionText.trim())}`),
+      },
+    );
+    added = true;
+  }
+  if (added || template.length > 0) template.push({ type: "separator" });
+  template.push({
+    label: "Select All",
+    click: () => void win.webContents.selectAll(),
+  });
+}
+
+async function saveFileAs(win: BrowserWindow, srcPath: string): Promise<void> {
+  const result = await dialog.showSaveDialog(win, { defaultPath: path.basename(srcPath) });
+  if (result.canceled || !result.filePath) return;
+  try {
+    await copyFile(srcPath, result.filePath);
+    shell.showItemInFolder(result.filePath);
+  } catch {
+    /* best-effort copy */
+  }
+}
+
+async function canReadAsText(filePath: string): Promise<boolean> {
+  try {
+    const st = await stat(filePath);
+    if (!st.isFile() || st.size > 1_000_000) return false;
+    const handle = await open(filePath, "r");
+    try {
+      const probe = Buffer.alloc(Math.min(8192, st.size));
+      const { bytesRead } = await handle.read(probe, 0, probe.length, 0);
+      return !probe.subarray(0, bytesRead).includes(0);
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function copyFileContents(filePath: string): Promise<void> {
+  try {
+    const buf = await readFile(filePath);
+    clipboard.writeText(buf.toString("utf8"));
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function buildFileContextMenu(
+  win: BrowserWindow,
+  filePath: string,
+  params: ContextMenuParams,
+  options?: { withTextItems?: boolean },
+): Promise<MenuItemConstructorOptions[]> {
+  return buildFileContextMenuCore(win, filePath, params, options);
+}
+
+async function buildFileContextMenuCore(
+  win: BrowserWindow,
+  filePath: string,
+  params: ContextMenuParams,
+  options?: { withTextItems?: boolean },
+): Promise<MenuItemConstructorOptions[]> {
+  const template: MenuItemConstructorOptions[] = [];
+  const fileExists = existsSync(filePath);
+  const { defaultApp, handlers } = await getFileAssociations(filePath);
+
+  template.push({ label: "Open file", enabled: fileExists, click: () => void shell.openPath(filePath) });
+  if (defaultApp) {
+    template.push({
+      label: `Open in ${defaultApp.name}`,
+      enabled: fileExists,
+      click: () => runOpenWith(defaultApp.command, filePath),
+    });
+  }
+
+  const openWithItems: MenuItemConstructorOptions[] = handlers.map((handler) => ({
+    label: handler.name,
+    enabled: fileExists,
+    click: () => runOpenWith(handler.command, filePath),
+  }));
+  if (openWithItems.length > 0) openWithItems.push({ type: "separator" });
+  openWithItems.push({
+    label: "Choose another app…",
+    enabled: fileExists,
+    click: () => openWithDialog(filePath),
+  });
+  template.push({ label: "Open with", submenu: openWithItems });
+
+  template.push({ type: "separator" });
+  template.push({ label: "Save as…", enabled: fileExists, click: () => void saveFileAs(win, filePath) });
+  template.push({ label: "Copy path", click: () => clipboard.writeText(filePath) });
+  const readableAsText = fileExists && (await canReadAsText(filePath));
+  template.push({
+    label: "Copy file contents",
+    enabled: readableAsText,
+    click: () => void copyFileContents(filePath),
+  });
+  template.push({ label: "Show in folder", enabled: fileExists, click: () => shell.showItemInFolder(filePath) });
+
+  // Skip text items (Cut/Copy/Paste, Select All) for renderer-driven menus:
+  // the renderer supplies synthetic params, so those items would be junk.
+  if (options?.withTextItems !== false) appendTextItems(template, params, win);
+  return template;
+}
+
+function setupContextMenu(win: BrowserWindow) {
+  win.webContents.on("context-menu", (_event, params) => {
+    const filePath = urlToWindowsPath(params.linkURL);
+
+    // Rich file menu on Windows (registry-backed "Open with"); built async.
+    if (filePath && process.platform === "win32") {
+      void buildFileContextMenu(win, filePath, params)
+        .then((template) => {
+          if (!win.isDestroyed()) Menu.buildFromTemplate(template).popup({ window: win });
+        })
+        .catch(() => {});
+      return;
+    }
+
+    const template: MenuItemConstructorOptions[] = [];
+    if (filePath) {
+      const resolvedPath: string = filePath;
+      const fileExists = existsSync(resolvedPath);
+      template.push({
+        label: "Show in folder",
+        enabled: fileExists,
+        click: () => shell.showItemInFolder(resolvedPath),
+      });
+      template.push({
+        label: "Open file",
+        enabled: fileExists,
+        click: () => void shell.openPath(resolvedPath),
+      });
+      template.push({
+        label: "Copy path",
+        click: () => clipboard.writeText(resolvedPath),
+      });
+    } else if (/^https?:\/\//i.test(params.linkURL)) {
+      template.push({
+        label: `Open in browser`,
+        click: () => void shell.openExternal(params.linkURL),
+      });
+      template.push({
+        label: `Copy link address`,
+        click: () => clipboard.writeText(params.linkURL),
+      });
+    }
+
+    appendTextItems(template, params, win);
+    Menu.buildFromTemplate(template).popup({ window: win });
+  });
+}
 
 export function createMainWindow(options: CreateMainWindowOptions): BrowserWindow {
   const ui = loadUiState();
@@ -60,6 +267,8 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
 
   trackWindowState(win);
   if (shouldMaximize(ui) && !win.isDestroyed()) win.maximize();
+
+  setupContextMenu(win);
 
   const showWin = () => {
     if (options.show === false) return;

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -4,7 +4,7 @@
  * MessagePort MUST NOT cross contextBridge via Promise resolve — that silently
  * breaks the port. Use window.postMessage transfer instead (Electron docs).
  */
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { DesktopMenuEvent, DesktopUpdateState, HostStatus, PiBridge } from "../contract/desktop";
 import type { BrowserEvent } from "../contract/browser";
 import { EarlyEventReplay } from "./early-event-replay";
@@ -70,6 +70,8 @@ if (typeof preloadLocation === "string" && isTrustedPreloadLocation(preloadLocat
     },
     openExternal: (url) => ipcRenderer.invoke("desktop:open-external", url),
     showItemInFolder: (fsPath) => ipcRenderer.invoke("desktop:show-item-in-folder", fsPath),
+    showFileContextMenu: (fsPath) => ipcRenderer.invoke("desktop:file-context-menu", fsPath),
+    getPathForFile: (file: File) => (webUtils ? webUtils.getPathForFile(file) : null),
     selectDirectory: () => ipcRenderer.invoke("desktop:select-directory"),
     setChannelCredential: (payload) => ipcRenderer.invoke("desktop:set-channel-credential", payload),
     saveFile: (opts) => ipcRenderer.invoke("desktop:save-file", opts),

--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -171,6 +171,27 @@ function slashMatchRank(command: SlashCommandPaletteItem, query: string): number
   return 4;
 }
 
+export interface AttachedFile {
+  name: string;
+  path: string;
+}
+
+/** Markdown link for an attached file: name escaped, path URL-encoded.
+ *  UNC paths (\\server\share\...) become file://server/share/... so the host survives. */
+function fileToMarkdownLink(file: AttachedFile): string {
+  const safeName = file.name.replace(/[[\]]/g, "\\$&");
+  const href = file.path
+    .replace(/\\/g, "/")
+    .replace(/%/g, "%25")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+    .replace(/ /g, "%20")
+    .replace(/#/g, "%23")
+    .replace(/\?/g, "%3F");
+  const prefix = href.startsWith("//") ? "file:" : "file:///";
+  return `[${safeName}](${prefix}${href})`;
+}
+
 function imageToDraftImage(image: AttachedImage): ChatDraftImage {
   return { data: image.data, mimeType: image.mimeType };
 }
@@ -188,8 +209,25 @@ function revokeImagePreview(image: AttachedImage): void {
   }
 }
 
+// Split queued text into plain segments and file-link segments so attached
+// files render as compact chips instead of raw "[name](file:///...)" markdown.
+function splitFileLinks(text: string): { text: string; file: string | null }[] {
+  const parts: { text: string; file: string | null }[] = [];
+  const re = /\[([^\]]+)\]\(file:\/\/[^)]+\)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    if (m.index > last) parts.push({ text: text.slice(last, m.index), file: null });
+    parts.push({ text: m[1], file: m[0] });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push({ text: text.slice(last), file: null });
+  return parts;
+}
+
 function QueuedMessageRow({ kind, text }: { kind: "steer" | "follow-up"; text: string }) {
   const { t } = useI18n();
+  const segments = splitFileLinks(text);
   return (
     <div
       title={text}
@@ -216,7 +254,31 @@ function QueuedMessageRow({ kind, text }: { kind: "steer" | "follow-up"; text: s
       >
         {kind === "steer" ? t("steer", "Steer") : t("followUp", "Follow-up")}
       </span>
-      <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{text}</span>
+      <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {segments.map((seg, i) =>
+          seg.file === null ? (
+            <span key={i}>{seg.text}</span>
+          ) : (
+            <span
+              key={i}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                padding: "0 6px",
+                margin: "0 2px",
+                borderRadius: 4,
+                border: "1px solid var(--border)",
+                background: "var(--bg-subtle)",
+                color: "var(--text)",
+                fontSize: 11,
+                verticalAlign: "baseline",
+              }}
+            >
+              {seg.text}
+            </span>
+          ),
+        )}
+      </span>
     </div>
   );
 }
@@ -274,6 +336,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
   const [attachedImages, setAttachedImagesState] = useState<AttachedImage[]>(() =>
     draftKey ? (getDraft(draftKey)?.images.map(draftImageToAttachedImage) ?? []) : [],
   );
+  const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>(() =>
+    draftKey ? (getDraft(draftKey)?.files?.map((file) => ({ ...file })) ?? []) : [],
+  );
   const [slashMenuOpen, setSlashMenuOpen] = useState(false);
   const [slashActiveIndex, setSlashActiveIndex] = useState(0);
   const [atQuery, setAtQuery] = useState<AtQueryMatch | null>(null);
@@ -330,8 +395,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     attachedImagesRef.current = resolved;
     setAttachedImagesState(resolved);
   }, []);
+  const attachedFilesRef = useRef(attachedFiles);
   valueRef.current = value;
   attachedImagesRef.current = attachedImages;
+  attachedFilesRef.current = attachedFiles;
 
   useImperativeHandle(ref, () => ({
     insertIfEmpty(text: string) {
@@ -388,36 +455,63 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       });
     },
     addImages(files: File[]) {
-      void processImageFiles(files);
+      void processFiles(files);
     },
   }));
 
-  const processImageFiles = useCallback(
+  const processFiles = useCallback(
     async (files: File[]) => {
-      if (isStreaming) return;
+      // Attaching is allowed while streaming; sending is gated separately
+      // (canQueueStreamingMessage / handleSend), so the user can prepare files
+      // for the next prompt while the agent is answering.
       const imageFiles = files.filter((f) => f.type.startsWith("image/"));
-      if (!imageFiles.length) return;
-      const generation = ++imageBatchGenerationRef.current;
-      const { images, failures } = await processImageFileBatch(imageFiles);
-      if (!imageProcessingActiveRef.current) {
-        images.forEach(revokeImagePreview);
-        return;
+      if (imageFiles.length) {
+        const generation = ++imageBatchGenerationRef.current;
+        const { images, failures } = await processImageFileBatch(imageFiles);
+        if (!imageProcessingActiveRef.current) {
+          images.forEach(revokeImagePreview);
+          return;
+        }
+        if (images.length > 0) {
+          images.forEach((image) => pendingImagePreviewsRef.current.add(image.previewUrl));
+          setAttachedImages((prev) => [...prev, ...images]);
+        }
+        if (generation === imageBatchGenerationRef.current) {
+          setImageAttachNotice(
+            failures.length === 0
+              ? null
+              : images.length > 0
+                ? `${failures.length} of ${imageFiles.length} images could not be attached.`
+                : "The selected images could not be attached.",
+          );
+        }
       }
-      if (images.length > 0) {
-        images.forEach((image) => pendingImagePreviewsRef.current.add(image.previewUrl));
-        setAttachedImages((prev) => [...prev, ...images]);
-      }
-      if (generation === imageBatchGenerationRef.current) {
-        setImageAttachNotice(
-          failures.length === 0
-            ? null
-            : images.length > 0
-              ? `${failures.length} of ${imageFiles.length} images could not be attached.`
-              : "The selected images could not be attached.",
-        );
+
+      // Non-image files become chips above the input; their markdown links are
+      // appended to the outgoing message at send time (see handleSend).
+      if (window.piBridge?.getPathForFile) {
+        const newFiles: AttachedFile[] = [];
+        for (const file of files) {
+          if (file.type.startsWith("image/")) continue;
+          const absPath = window.piBridge.getPathForFile(file);
+          if (absPath) newFiles.push({ name: file.name, path: absPath });
+        }
+        // Clipboard files without a filesystem path (mail client, messenger)
+        // resolve to nothing — tell the user instead of silently dropping them.
+        const nonImageCount = files.length - imageFiles.length;
+        if (nonImageCount > 0 && newFiles.length === 0) {
+          setImageAttachNotice(
+            "Only files with a real path can be attached (drag from Explorer or use the attach button).",
+          );
+        }
+        if (newFiles.length)
+          setAttachedFiles((prev) => {
+            const seen = new Set(prev.map((f) => f.path));
+            return [...prev, ...newFiles.filter((f) => !seen.has(f.path))];
+          });
       }
     },
-    [isStreaming, setAttachedImages],
+    [setAttachedImages],
   );
 
   const removeImage = useCallback(
@@ -439,6 +533,10 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     });
   }, [setAttachedImages]);
 
+  const removeFile = useCallback((index: number) => {
+    setAttachedFiles((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
   const clearInput = useCallback(() => {
     setValue("");
     setAtQuery(null);
@@ -447,6 +545,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       draftPersistenceRef.current?.clear(draftKeyRef.current);
     }
     clearImages();
+    setAttachedFiles([]);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
@@ -458,6 +557,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       if (action === "restore") {
         setValue(snapshot.value);
         setAttachedImages(snapshot.images);
+        setAttachedFiles(snapshot.files ?? []);
       } else if (snapshot.images.length > 0) {
         setAttachedImages((current) => mergeFailedSubmissionImages(current, snapshot.images));
       }
@@ -488,8 +588,9 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     draftPersistenceRef.current?.schedule(draftKey, {
       value,
       images: attachedImages.map(imageToDraftImage),
+      files: attachedFiles,
     });
-  }, [attachedImages, draftKey, value]);
+  }, [attachedFiles, attachedImages, draftKey, value]);
 
   useEffect(() => {
     const previousDraftKey = draftKeyRef.current;
@@ -499,6 +600,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       draftPersistenceRef.current?.commit(previousDraftKey, {
         value: valueRef.current,
         images: attachedImagesRef.current.map(imageToDraftImage),
+        files: attachedFilesRef.current,
       });
     }
 
@@ -510,6 +612,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       prev.forEach(revokeImagePreview);
       return draft?.images.map(draftImageToAttachedImage) ?? [];
     });
+    setAttachedFiles(draft?.files?.map((file) => ({ ...file })) ?? []);
   }, [draftKey, setAttachedImages, setValue]);
 
   useEffect(() => {
@@ -537,17 +640,18 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
   }, [commitCurrentDraft]);
 
   const handleSend = useCallback(async () => {
-    const msg = value.trim();
+    const text = value.trim();
+    const msg = [text, ...attachedFiles.map(fileToMarkdownLink)].filter(Boolean).join(" ");
     if (!msg && !attachedImages.length) return;
     if (isStreaming) return;
     onAudioUnlock?.();
-    const snapshot = captureComposerSubmission(value, attachedImages);
+    const snapshot = captureComposerSubmission(value, attachedImages, attachedFiles);
     setSubmissionNotice(null);
     commitCurrentDraft();
     clearInput();
     const clearedAtRevision = inputRevisionRef.current;
     try {
-      if (!attachedImages.length && msg.startsWith("/") && onBuiltinCommand) {
+      if (!attachedImages.length && !attachedFiles.length && msg.startsWith("/") && onBuiltinCommand) {
         const result = await onBuiltinCommand(msg);
         if (result.handled) {
           if (result.error) restoreFailedSubmission(snapshot, clearedAtRevision, "send");
@@ -565,6 +669,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       restoreFailedSubmission(snapshot, clearedAtRevision, "send");
     }
   }, [
+    attachedFiles,
     attachedImages,
     clearInput,
     commitCurrentDraft,
@@ -617,7 +722,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
         : "1 command"
       : `${filteredSlashCommands.length} ${slashQuery ? "matches" : "commands"}`;
   const hasInputText = Boolean(value.trim());
-  const canQueueStreamingMessage = hasInputText && attachedImages.length === 0;
+  const canQueueStreamingMessage = hasInputText || attachedFiles.length > 0 || attachedImages.length > 0;
 
   // ── @ file autocomplete ──────────────────────────────────────────────────
   // Recomputed from the text before the caret on every change/caret move.
@@ -799,31 +904,34 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
 
   const sendQueued = useCallback(
     async (mode: "steer" | "followup") => {
-      const msg = value.trim();
+      // Files are plain markdown links in the message text; images go through
+      // the SDK's steer/followUp image parameter — both queue fine mid-stream.
+      const msg = [value.trim(), ...attachedFiles.map(fileToMarkdownLink)].filter(Boolean).join(" ");
       if (!msg && !attachedImages.length) return;
-      if (attachedImages.length) return;
       onAudioUnlock?.();
-      const snapshot = captureComposerSubmission(value, attachedImages);
+      const snapshot = captureComposerSubmission(value, attachedImages, attachedFiles);
       const streamingBehavior = mode === "steer" ? "steer" : "followUp";
       setSubmissionNotice(null);
       commitCurrentDraft();
       clearInput();
       const clearedAtRevision = inputRevisionRef.current;
       try {
+        const images = attachedImages.length ? attachedImages : undefined;
         if (msg.startsWith("/") && onPromptWithStreamingBehavior) {
-          await Promise.resolve(onPromptWithStreamingBehavior(msg, streamingBehavior, undefined));
+          await Promise.resolve(onPromptWithStreamingBehavior(msg, streamingBehavior, images));
           return;
         }
         if (mode === "steer" && onSteer) {
-          await Promise.resolve(onSteer(msg, undefined));
+          await Promise.resolve(onSteer(msg, images));
         } else if (mode === "followup" && onFollowUp) {
-          await Promise.resolve(onFollowUp(msg, undefined));
+          await Promise.resolve(onFollowUp(msg, images));
         }
       } catch {
         restoreFailedSubmission(snapshot, clearedAtRevision, "queue");
       }
     },
     [
+      attachedFiles,
       attachedImages,
       clearInput,
       commitCurrentDraft,
@@ -987,13 +1095,13 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
       const items = Array.from(e.clipboardData?.items ?? []);
-      const imageItems = items.filter((item) => item.type.startsWith("image/"));
-      if (!imageItems.length) return;
+      const fileItems = items.filter((item) => item.kind === "file");
+      if (!fileItems.length) return;
       e.preventDefault();
-      const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
-      void processImageFiles(files);
+      const files = fileItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
+      void processFiles(files);
     },
-    [processImageFiles],
+    [processFiles],
   );
 
   useEffect(() => {
@@ -1206,13 +1314,11 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
       <input
         ref={fileInputRef}
         type="file"
-        accept="image/*"
         multiple
-        disabled={isStreaming}
         style={{ display: "none" }}
         onChange={(e) => {
           const files = Array.from(e.target.files ?? []);
-          void processImageFiles(files);
+          void processFiles(files);
           e.target.value = "";
         }}
       />
@@ -1474,6 +1580,81 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                     cursor: "pointer",
                     padding: 0,
                     color: "var(--text-muted)",
+                  }}
+                >
+                  <svg
+                    width="8"
+                    height="8"
+                    viewBox="0 0 8 8"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  >
+                    <line x1="1" y1="1" x2="7" y2="7" />
+                    <line x1="7" y1="1" x2="1" y2="7" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* File attachment chips */}
+        {attachedFiles.length > 0 && (
+          <div style={{ display: "flex", gap: 6, marginBottom: 6, flexWrap: "wrap" }}>
+            {attachedFiles.map((file, i) => (
+              <div
+                key={`${file.path}-${i}`}
+                title={file.path}
+                onClick={() => void window.piBridge?.showItemInFolder?.(file.path)}
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 6,
+                  maxWidth: 260,
+                  padding: "4px 6px 4px 8px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "var(--bg-panel)",
+                  cursor: "pointer",
+                  fontSize: 12,
+                }}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ flexShrink: 0, color: "var(--text-muted)" }}
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                </svg>
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{file.name}</span>
+                <button
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    removeFile(i);
+                  }}
+                  title="Remove"
+                  style={{
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    background: "transparent",
+                    border: "none",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    cursor: "pointer",
+                    padding: 0,
+                    color: "var(--text-muted)",
+                    flexShrink: 0,
                   }}
                 >
                   <svg
@@ -1890,7 +2071,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
             ) : (
               <button
                 onClick={handleSend}
-                disabled={!value.trim() && !attachedImages.length}
+                disabled={!value.trim() && !attachedImages.length && !attachedFiles.length}
                 style={{
                   flexShrink: 0,
                   alignSelf: "flex-end",
@@ -1898,17 +2079,21 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                   alignItems: "center",
                   gap: 6,
                   padding: "10px 18px",
-                  background: value.trim() || attachedImages.length ? "var(--accent)" : "var(--bg-hover)",
+                  background:
+                    value.trim() || attachedImages.length || attachedFiles.length ? "var(--accent)" : "var(--bg-hover)",
                   border: "none",
                   borderRadius: 9,
-                  color: value.trim() || attachedImages.length ? "var(--on-accent)" : "var(--text-dim)",
-                  cursor: value.trim() || attachedImages.length ? "pointer" : "not-allowed",
+                  color:
+                    value.trim() || attachedImages.length || attachedFiles.length
+                      ? "var(--on-accent)"
+                      : "var(--text-dim)",
+                  cursor: value.trim() || attachedImages.length || attachedFiles.length ? "pointer" : "not-allowed",
                   fontSize: 12.5,
                   fontWeight: 700,
                   fontFamily: "var(--font-mono)",
                   letterSpacing: "-0.01em",
                   boxShadow:
-                    value.trim() || attachedImages.length
+                    value.trim() || attachedImages.length || attachedFiles.length
                       ? "0 1px 3px color-mix(in srgb, var(--accent) 30%, transparent)"
                       : "none",
                   transition: "background 0.15s, box-shadow 0.15s",
@@ -1942,7 +2127,6 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
           >
             <button
               onClick={() => fileInputRef.current?.click()}
-              disabled={isStreaming}
               title={t("attachImage", "Attach image")}
               style={{
                 flexShrink: 0,

--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -404,10 +404,10 @@ export function ChatWindow({
 
   const onDrop = useCallback(
     (files: File[]) => {
-      if (agentRunning) return;
+      // Attaching while the agent runs is fine — send stays gated separately.
       chatInputRef?.current?.addImages(files);
     },
-    [agentRunning, chatInputRef],
+    [chatInputRef],
   );
 
   const { isDragOver, handleDragEnter, handleDragOver, handleDragLeave, handleDrop } = useDragDrop(onDrop);
@@ -533,7 +533,7 @@ export function ChatWindow({
       <div className="chat-corner-tick chat-corner-tick-bl" aria-hidden="true" />
       <div className="chat-corner-tick chat-corner-tick-br" aria-hidden="true" />
 
-      {isDragOver && !agentRunning && (
+      {isDragOver && (
         <div
           className="pointer-events-none absolute inset-0 z-50 flex animate-[drop-zone-in_0.15s_ease_both] items-center justify-center backdrop-blur-[1px]"
           style={{ background: "color-mix(in srgb, var(--accent) 6%, transparent)" }}

--- a/src/renderer/components/MarkdownBody.tsx
+++ b/src/renderer/components/MarkdownBody.tsx
@@ -9,12 +9,12 @@ import {
   type MouseEvent,
   type ReactNode,
 } from "react";
-import ReactMarkdown, { type Components } from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
 import { SyntaxHighlighter, vs, vscDarkPlus } from "@/lib/syntax-highlight";
 import { useTheme } from "@/hooks/useTheme";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
 import { resolveLocalFileHref } from "@/lib/file-links";
-import { markdownRehypePlugins, markdownRemarkPlugins } from "@/lib/markdown";
+import { markdownRehypePlugins, markdownRemarkPlugins, autolinkPathsInMarkdown } from "@/lib/markdown";
 import { shouldHighlightCode } from "@/lib/code-highlight-policy";
 import { mermaidCacheKey, renderMermaidSvg } from "@/lib/mermaid-renderer";
 import { SessionProfiler } from "./SessionProfiler";
@@ -73,17 +73,34 @@ function MarkdownAnchor({ href, children, node: _node, ...props }: MarkdownCompo
     );
   }
 
+  // Absolute links (attachments, agent-printed paths) reveal in Explorer;
+  // relative repo links still open in the in-app viewer.
+  const hrefText = typeof href === "string" ? href : "";
+  const revealInFolder = /^file:/i.test(hrefText) || /^[a-zA-Z]:[\\/]/.test(hrefText) || hrefText.startsWith("/");
+
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     if (event.defaultPrevented || event.button !== 0) return;
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
     const target = event.currentTarget.getAttribute("target");
     if (target && target !== "_self") return;
     event.preventDefault();
+    if (revealInFolder && window.piBridge?.showItemInFolder) {
+      void window.piBridge.showItemInFolder(filePath);
+      return;
+    }
     onOpenFile(filePath);
   };
 
+  const handleContextMenu = (event: MouseEvent<HTMLAnchorElement>) => {
+    // Chromium (Electron 43) does not reliably report file: links in the
+    // native context-menu event, so we show the rich file menu ourselves.
+    if (event.defaultPrevented) return;
+    event.preventDefault();
+    void window.piBridge?.showFileContextMenu?.(filePath);
+  };
+
   return (
-    <a href={href} {...props} onClick={handleClick}>
+    <a href={href} {...props} onClick={handleClick} onContextMenu={handleContextMenu}>
       {children}
     </a>
   );
@@ -119,6 +136,14 @@ const markdownComponents: Components = {
   table: MarkdownTable,
 };
 
+// react-markdown 10 strips non-web protocols from href/src via defaultUrlTransform
+// (file: becomes ""). Local file links are this app's core feature, so allow file:.
+type UrlTransform = (url: string, key: string, node: unknown) => string;
+const fileAwareUrlTransform: UrlTransform = (url, key, node) => {
+  if (/^file:/i.test(url)) return url;
+  return (defaultUrlTransform as UrlTransform)(url, key, node);
+};
+
 export function MarkdownBody({
   children,
   className,
@@ -128,7 +153,7 @@ export function MarkdownBody({
   sourceSessionId,
   onOpenFile,
 }: MarkdownBodyProps) {
-  const normalizedMarkdown = useMemo(() => normalizeDisplayMath(children), [children]);
+  const normalizedMarkdown = useMemo(() => autolinkPathsInMarkdown(normalizeDisplayMath(children)), [children]);
   const renderContext = useMemo(
     () => ({ isStreaming, cwd, imageBasePath, sourceSessionId, onOpenFile }),
     [cwd, imageBasePath, isStreaming, onOpenFile, sourceSessionId],
@@ -141,6 +166,7 @@ export function MarkdownBody({
           <ReactMarkdown
             remarkPlugins={markdownRemarkPlugins}
             rehypePlugins={markdownRehypePlugins}
+            urlTransform={fileAwareUrlTransform}
             components={markdownComponents}
           >
             {normalizedMarkdown}

--- a/src/renderer/components/markdown-body-component-identity.test.mjs
+++ b/src/renderer/components/markdown-body-component-identity.test.mjs
@@ -23,7 +23,7 @@ const { getMarkdownComponentIdentityForTest } = await importTestBundle(
                 : args.path === "@/lib/file-links"
                   ? "export const resolveLocalFileHref = () => null;"
                   : args.path === "@/lib/markdown"
-                    ? "export const markdownRehypePlugins = []; export const markdownRemarkPlugins = [];"
+                    ? "export const markdownRehypePlugins = []; export const markdownRemarkPlugins = []; export const autolinkPathsInMarkdown = (s) => s;"
                     : args.path === "@/lib/code-highlight-policy"
                       ? "export const shouldHighlightCode = () => false;"
                       : args.path === "@/lib/mermaid-renderer"

--- a/src/renderer/hooks/queued-command-error-contract.test.mjs
+++ b/src/renderer/hooks/queued-command-error-contract.test.mjs
@@ -30,7 +30,7 @@ test("queued command handlers reject a missing-session race", () => {
 test("ChatInput awaits queue handlers and restores revision-aware snapshots after rejection", () => {
   assert.match(inputSource, /onSteer\?:[\s\S]*?Promise<void> \| void/);
   assert.match(inputSource, /onFollowUp\?:[\s\S]*?Promise<void> \| void/);
-  assert.match(inputSource, /await Promise\.resolve\(onSteer\(msg, undefined\)\)/);
-  assert.match(inputSource, /await Promise\.resolve\(onFollowUp\(msg, undefined\)\)/);
+  assert.match(inputSource, /await Promise\.resolve\(onSteer\(msg, images\)\)/);
+  assert.match(inputSource, /await Promise\.resolve\(onFollowUp\(msg, images\)\)/);
   assert.match(inputSource, /catch \{\s*restoreFailedSubmission\(snapshot, clearedAtRevision, "queue"\)/);
 });

--- a/src/renderer/hooks/useDragDrop.ts
+++ b/src/renderer/hooks/useDragDrop.ts
@@ -4,17 +4,17 @@ export function useDragDrop(onDrop: (files: File[]) => void) {
   const [isDragOver, setIsDragOver] = useState(false);
   const counterRef = useRef(0);
 
+  const hasFiles = (e: React.DragEvent) => Array.from(e.dataTransfer.items).some((item) => item.kind === "file");
+
   const handleDragEnter = useCallback((e: React.DragEvent) => {
-    const hasImages = Array.from(e.dataTransfer.items).some((item) => item.type.startsWith("image/"));
-    if (!hasImages) return;
+    if (!hasFiles(e)) return;
     e.preventDefault();
     counterRef.current += 1;
     setIsDragOver(true);
   }, []);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
-    const hasImages = Array.from(e.dataTransfer.items).some((item) => item.type.startsWith("image/"));
-    if (!hasImages) return;
+    if (!hasFiles(e)) return;
     e.preventDefault();
   }, []);
 
@@ -32,7 +32,7 @@ export function useDragDrop(onDrop: (files: File[]) => void) {
       counterRef.current = 0;
       setIsDragOver(false);
       const files = Array.from(e.dataTransfer.files);
-      onDrop(files);
+      if (files.length) onDrop(files);
     },
     [onDrop],
   );

--- a/src/renderer/lib/composer-submission.test.mjs
+++ b/src/renderer/lib/composer-submission.test.mjs
@@ -16,6 +16,7 @@ test("submission snapshots use durable previews before composer URLs are revoked
   assert.deepEqual(captureComposerSubmission("hello", [image("abc")]), {
     value: "hello",
     images: [{ data: "abc", mimeType: "image/png", previewUrl: "data:image/png;base64,abc" }],
+    files: [],
   });
 });
 

--- a/src/renderer/lib/composer-submission.ts
+++ b/src/renderer/lib/composer-submission.ts
@@ -4,14 +4,21 @@ export interface ComposerSubmissionImage {
   previewUrl: string;
 }
 
+export interface ComposerSubmissionFile {
+  name: string;
+  path: string;
+}
+
 export interface ComposerSubmissionSnapshot {
   value: string;
   images: ComposerSubmissionImage[];
+  files: ComposerSubmissionFile[];
 }
 
 export function captureComposerSubmission(
   value: string,
   images: readonly ComposerSubmissionImage[],
+  files: readonly ComposerSubmissionFile[] = [],
 ): ComposerSubmissionSnapshot {
   return {
     value,
@@ -19,6 +26,7 @@ export function captureComposerSubmission(
       ...image,
       previewUrl: `data:${image.mimeType};base64,${image.data}`,
     })),
+    files: files.map((file) => ({ ...file })),
   };
 }
 

--- a/src/renderer/lib/draft-persistence.test.mjs
+++ b/src/renderer/lib/draft-persistence.test.mjs
@@ -103,7 +103,7 @@ test("staging a draft performs no synchronous localStorage write until flush", (
     flushDraft("debounce-proof");
     assert.equal(writes.length, 1);
     assert.equal(writes[0][0], "set");
-    assert.deepEqual(JSON.parse(writes[0][2]), { value: "draft", images: [] });
+    assert.deepEqual(JSON.parse(writes[0][2]), { value: "draft", images: [], files: [] });
   } finally {
     if (descriptor) Object.defineProperty(globalThis, "localStorage", descriptor);
     else delete globalThis.localStorage;

--- a/src/shared/draft-store.ts
+++ b/src/shared/draft-store.ts
@@ -3,9 +3,15 @@ export interface ChatDraftImage {
   mimeType: string;
 }
 
+export interface ChatDraftFile {
+  name: string;
+  path: string;
+}
+
 export interface ChatDraft {
   value: string;
   images: ChatDraftImage[];
+  files?: ChatDraftFile[];
 }
 
 const drafts = new Map<string, ChatDraft | null>();
@@ -16,11 +22,12 @@ function cloneDraft(draft: ChatDraft): ChatDraft {
   return {
     value: draft.value,
     images: draft.images.map((image) => ({ ...image })),
+    files: draft.files?.map((file) => ({ ...file })),
   };
 }
 
 function isEmptyDraft(draft: ChatDraft): boolean {
-  return !draft.value && draft.images.length === 0;
+  return !draft.value && draft.images.length === 0 && (draft.files?.length ?? 0) === 0;
 }
 
 function persistKey(key: string): string {
@@ -53,6 +60,7 @@ function loadFromStorage(key: string): ChatDraft | null {
     return {
       value: parsed.value,
       images: Array.isArray(parsed.images) ? parsed.images.slice(0, 4) : [],
+      files: Array.isArray(parsed.files) ? parsed.files.slice(0, 8) : [],
     };
   } catch {
     return null;
@@ -71,6 +79,7 @@ function saveToStorage(key: string, draft: ChatDraft | null): void {
     const toStore: ChatDraft = {
       value: draft.value,
       images: persistableDraftImages(draft.images),
+      files: draft.files ?? [],
     };
     localStorage.setItem(persistKey(key), JSON.stringify(toStore));
   } catch {

--- a/src/shared/markdown.test.mjs
+++ b/src/shared/markdown.test.mjs
@@ -18,3 +18,114 @@ test("Markdown plugins preserve GFM/math and sanitize raw HTML before KaTeX", ()
   assert.deepEqual(schema.strip.slice(-4), ["iframe", "object", "style", "form"]);
   assert.deepEqual(schema.attributes.code, [["className", /^language-./, "math-inline", "math-display"]]);
 });
+
+async function loadSubject() {
+  return import("./markdown.ts");
+}
+
+const WB = String.raw;
+
+test("autolinks Windows absolute path with spaces (trailing word cut)", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown(WB`Build: C:\Users\Anarki\x\Pi Agent Desktop.exe big`);
+  assert.ok(out.includes(WB`[C:\Users\Anarki\x\Pi Agent Desktop.exe]`), out);
+  // href must be a canonical file:/// URL — a bare "C:\" href is stripped by the sanitizer
+  assert.ok(out.includes("](file:///C:/Users/Anarki/x/Pi%20Agent%20Desktop.exe)"), out);
+  assert.ok(!out.includes("big]"), out + " <- 'big' must stay outside link");
+});
+
+test("autolinks posix absolute path", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("file at /home/me/project/src/main.ts line 5");
+  assert.ok(out.includes("[/home/me/project/src/main.ts]"), out);
+});
+
+test("autolinks bare https URL keeping query string", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("see https://example.com/a?b=1&c=2 ok");
+  assert.ok(out.includes("[https://example.com/a?b=1&c=2]"), out);
+});
+
+test("skips lines that already contain markdown links", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("see [build](dist/foo.exe) end");
+  assert.equal(out, "see [build](dist/foo.exe) end");
+});
+
+test("trims trailing comma from linked path", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown(WB`go to C:\tmp\x.txt, then`);
+  assert.ok(out.includes(WB`[C:\tmp\x.txt](file:///C:/tmp/x.txt)`), out);
+  assert.ok(out.endsWith(", then"));
+});
+
+test("bare file:// URL keeps its href and encodes spaces", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("open file:///C:/Users/me/file.txt please");
+  assert.ok(out.includes("[file:///C:/Users/me/file.txt](file:///C:/Users/me/file.txt)"), out);
+});
+
+test("sanitize schema keeps file: hrefs (otherwise links render dead)", async () => {
+  const { markdownSanitizeSchema } = await loadSubject();
+  const hrefProtocols = markdownSanitizeSchema.protocols?.href ?? [];
+  assert.ok(hrefProtocols.includes("file"), JSON.stringify(hrefProtocols));
+  assert.ok(hrefProtocols.includes("https"));
+});
+
+test("does not autolink bare drive letter without file (C:\\ only)", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("root is C:\\ or C:/");
+  assert.ok(!out.includes("]["), out);
+});
+
+test("URL containing $& keeps text and href intact (replacement-pattern safe)", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("open https://x.com/a$&b now");
+  assert.ok(out.includes("[https://x.com/a$&b](https://x.com/a$&b)"), out);
+});
+
+test("protects inline code spans from autolinking", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("use `C:\\tmp\\x.txt` here and https://y.com now");
+  assert.ok(out.includes("`C:\\tmp\\x.txt`"), out);
+  assert.ok(out.includes("[https://y.com]"), out);
+});
+
+test("protects fenced code blocks from autolinking", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const md = ["```text", "https://example.com/x", "C:\\tmp\\y.exe", "```", "then https://z.org"].join("\n");
+  const out = autolinkPathsInMarkdown(md);
+  assert.ok(out.includes("[https://z.org]"), out);
+  assert.ok(!out.includes("[https://example.com/x]"), out);
+});
+
+test("autolinks UNC path to file://server/share form", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const input =
+    "open " +
+    String.fromCharCode(92, 92) +
+    "server" +
+    String.fromCharCode(92) +
+    "share" +
+    String.fromCharCode(92) +
+    "dir" +
+    String.fromCharCode(92) +
+    "report.docx please";
+  const out = autolinkPathsInMarkdown(input);
+  assert.ok(out.includes("](file://server/share/dir/report.docx)"), out);
+});
+
+test("bare % in file:// URL is encoded, valid escapes are preserved", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const out = autolinkPathsInMarkdown("file:///C:/100%done.txt and file:///C:/a%20b.txt");
+  assert.ok(out.includes("100%25done.txt"), out);
+  assert.ok(out.includes("a%20b.txt"), out);
+});
+
+test("autolinks Windows path with unicode and spaces", async () => {
+  const { autolinkPathsInMarkdown } = await loadSubject();
+  const bs = String.fromCharCode(92);
+  const input = "файл C:" + bs + "Users" + bs + "Анарки" + bs + "мои документы" + bs + "отчёт.docx тут";
+  const out = autolinkPathsInMarkdown(input);
+  assert.ok(out.includes("file:///C:/Users/Анарки/мои%20документы/отчёт.docx"), out);
+});

--- a/src/shared/markdown.test.mjs
+++ b/src/shared/markdown.test.mjs
@@ -27,10 +27,10 @@ const WB = String.raw;
 
 test("autolinks Windows absolute path with spaces (trailing word cut)", async () => {
   const { autolinkPathsInMarkdown } = await loadSubject();
-  const out = autolinkPathsInMarkdown(WB`Build: C:\Users\Anarki\x\Pi Agent Desktop.exe big`);
-  assert.ok(out.includes(WB`[C:\Users\Anarki\x\Pi Agent Desktop.exe]`), out);
+  const out = autolinkPathsInMarkdown(WB`Build: C:\Users\tester\x\Pi Agent Desktop.exe big`);
+  assert.ok(out.includes(WB`[C:\Users\tester\x\Pi Agent Desktop.exe]`), out);
   // href must be a canonical file:/// URL — a bare "C:\" href is stripped by the sanitizer
-  assert.ok(out.includes("](file:///C:/Users/Anarki/x/Pi%20Agent%20Desktop.exe)"), out);
+  assert.ok(out.includes("](file:///C:/Users/tester/x/Pi%20Agent%20Desktop.exe)"), out);
   assert.ok(!out.includes("big]"), out + " <- 'big' must stay outside link");
 });
 

--- a/src/shared/markdown.ts
+++ b/src/shared/markdown.ts
@@ -5,14 +5,129 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
-const markdownSanitizeSchema = {
+export const markdownSanitizeSchema = {
   ...defaultSchema,
   attributes: {
     ...defaultSchema.attributes,
     code: [["className", /^language-./, "math-inline", "math-display"]],
   },
+  protocols: {
+    ...defaultSchema.protocols,
+    // file: links (attachments, agent-printed paths) must keep their href —
+    // otherwise sanitize strips it and the link renders as dead text.
+    href: [...(defaultSchema.protocols?.href ?? []), "file"],
+  },
   strip: [...(defaultSchema.strip || []), "iframe", "object", "style", "form"],
 };
+
+// ---------------------------------------------------------------------------
+// Autolink bare paths / URLs in prose so they render as clickable links:
+//   file:///C:/x/y     → file link
+//   C:\Users\me\a.exe  → file link
+//   /home/me/file.txt    → file link
+//   https://... / http://... → web link
+// The MarkdownBody <a> renderer turns file links into "open in editor/explorer".
+// ---------------------------------------------------------------------------
+
+// Path segment: anything except filesystem-illegal chars and line breaks
+// (spaces and unicode allowed; excludes tab, newline, / \ : * ? " < > |).
+const PATH_SEGMENT = '[^\\t\\n\\\\/:*?"<>|]+';
+const BARE_PATH_RE = new RegExp(
+  "(?<![\\w])(" +
+    "file:\\/\\/[^\\s<>\"']+" +
+    `|[A-Za-z]:[\\\\/](?:${PATH_SEGMENT}[\\\\/])*${PATH_SEGMENT}\\.[A-Za-z0-9]+(?::\\d+)?` +
+    // UNC: \\\\server\\share\\file.txt — regex \\\\ matches two literal backslashes,
+    // so the template literal needs eight.
+    `|\\\\\\\\(?:${PATH_SEGMENT}[\\\\/])+${PATH_SEGMENT}\\.[A-Za-z0-9]+(?::\\d+)?` +
+    `|\\/(?:${PATH_SEGMENT}\\/)*[\\w.~-]+\\.[A-Za-z0-9]+(?::\\d+)?` +
+    "|https?:\\/\\/[^\\s<>\"']+" +
+    "|ftp:\\/\\/[^\\s<>\"']+" +
+    ")",
+  "gu",
+);
+
+function encodeFileUrl(pathPart: string): string {
+  return pathPart
+    .replace(/%/g, "%25")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29")
+    .replace(/ /g, "%20")
+    .replace(/#/g, "%23")
+    .replace(/\?/g, "%3F");
+}
+
+function linkifyPath(match: string): string {
+  // Trim trailing sentence punctuation so ","/"."/";" don't join the link.
+  const cleaned = match.replace(/[.,;:!?)\]}]+$/, "");
+  if (!cleaned) return match;
+
+  let target: string;
+  if (/^(https?|ftp):\/\//i.test(cleaned)) {
+    // Web URL: only markdown-breaking parens need escaping (spaces can't occur here).
+    target = cleaned.replace(/\(/g, "%28").replace(/\)/g, "%29");
+  } else if (/^file:\/\//i.test(cleaned)) {
+    // Already a file URL: encode what breaks markdown/URL parsing, keep the rest.
+    // Bare % that isn't a valid escape must be encoded first, or a later
+    // decodeURIComponent (window.ts urlToWindowsPath) turns the link dead.
+    target = cleaned
+      .replace(/%(?![0-9A-Fa-f]{2})/g, "%25")
+      .replace(/\(/g, "%28")
+      .replace(/\)/g, "%29")
+      .replace(/ /g, "%20")
+      .replace(/#/g, "%23")
+      .replace(/\?/g, "%3F");
+  } else if (/^\\\\/.test(cleaned)) {
+    // UNC path -> file://server/share (matches fileToMarkdownLink in ChatInput).
+    target = "file:" + encodeFileUrl(cleaned.replace(/\\/g, "/"));
+  } else if (/^[a-zA-Z]:[\\/]/.test(cleaned)) {
+    // Windows drive path -> canonical file:/// URL (a bare "C:\..." href would be
+    // read as protocol "c:" and stripped by the sanitizer).
+    target = "file:///" + encodeFileUrl(cleaned.replace(/\\/g, "/"));
+  } else {
+    // Posix absolute path: protocol-less href passes the sanitizer as-is.
+    target = cleaned.replace(/\(/g, "%28").replace(/\)/g, "%29").replace(/ /g, "%20");
+  }
+  // Function replacement: URL chars like $& would otherwise be treated as
+  // special replacement patterns and corrupt the link.
+  return match.replace(cleaned, () => `[${cleaned}](${target})`);
+}
+
+export function autolinkPathsInMarkdown(markdown: string): string {
+  const lineBreak = markdown.includes("\r\n") ? "\r\n" : "\n";
+  const lines = markdown.split(/\r?\n/);
+  let fence: { marker: string; size: number } | null = null;
+
+  return lines
+    .map((line) => {
+      const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+      if (fenceMatch) {
+        const marker = fenceMatch[1][0];
+        const size = fenceMatch[1].length;
+        if (!fence) fence = { marker, size };
+        else if (marker === fence.marker && size >= fence.size) fence = null;
+        return line;
+      }
+      if (fence) return line;
+
+      // Skip lines that already look like markdown links / images to avoid double-wrapping
+      // (common in agent output: "see [build](dist/)" etc).
+      if (line.includes("](") || line.trimStart().startsWith("![")) return line;
+
+      // Protect inline code spans (single backticks) from being linkified.
+      const spans = line.split(/(`+)/);
+      let inCode = false;
+      return spans
+        .map((span) => {
+          if (span.startsWith("`")) {
+            inCode = !inCode;
+            return span;
+          }
+          return inCode ? span : span.replace(BARE_PATH_RE, linkifyPath);
+        })
+        .join("");
+    })
+    .join(lineBreak);
+}
 
 export const markdownRemarkPlugins: ReactMarkdownOptions["remarkPlugins"] = [remarkGfm, remarkMath];
 


### PR DESCRIPTION
## Summary

End-to-end local file support in chat: attach any file type, autolink file paths in messages, and a Windows-native context menu on file links.

## Commits (review order)

**1. `feat(chat): attach any file as chips; send & queue with files/images mid-stream`**
- Drag-drop / paste / attach-button accept any file type; non-image files become chips above the composer (dedup by path, click reveals in Explorer)
- Real paths resolved via preload `webUtils.getPathForFile`
- Send button enabled with files-only (no text); steer/follow-up queueing accepts files (as markdown links) and images (SDK image param) while streaming
- Queued rows render file links as chips, not raw markdown
- Composer snapshots/drafts persist attached files; paste of a clipboard file without a filesystem path shows a notice instead of silently dropping

**2. `feat(markdown): autolink local file paths; keep file: hrefs clickable`**
- Bare `C:\...`, POSIX, and UNC (`\\server\share`) paths in message text are autolinked (unicode + spaces supported; code spans/fences protected)
- Root-cause fix: react-markdown v10 `defaultUrlTransform` strips `file:` hrefs to `""` — a file-aware transform keeps them
- Sanitize schema allows the `file:` protocol; bare `%` in file URLs is encoded without double-encoding valid escapes
- Absolute file links reveal in Explorer on click; relative repo links still open in the in-app viewer

**3. `feat(files): rich file context menu with registry-backed open-with`**
- Right-click a file link: Open file / Open in \<default\> / Open with ▸ / Save as… / Copy path / Copy file contents / Show in folder
- The open-with list is read live from the registry (UserChoice, OpenWithProgids, OpenWithList, App Paths); shells/terminals are excluded
- Pretty app names come from the exe FileDescription version resource ("Visual Studio Code", not "Code") via a single batched PowerShell call; cached per extension
- Commands run via spawn without shell (paths with `%`, parens, spaces survive); `%1`/`%*` substitution and `%ENV%` expansion supported
- Note: Electron 43 does not report `file:` in `params.linkURL`, so the renderer hands the resolved path over IPC (`desktop:file-context-menu`, absolute-path validated) and main builds the menu

## Test

- ✅ typecheck / ESLint / Prettier / i18n parity
- ✅ renderer tests pass (incl. new autolink UNC/unicode/percent cases)
- ✅ verified live on Windows: chips, send/queue mid-stream, menu with real associations, reveal-in-folder on click
