### PR TITLE
feat(desktop): live subagent trail and sticky live-chat scroll

### DIFF
--- a/docs/plans/2026-08-17-001-feat-subagent-tool-card-status-plan.md
+++ b/docs/plans/2026-08-17-001-feat-subagent-tool-card-status-plan.md
@@ -1,0 +1,318 @@
+---
+title: Subagent Tool Card Status - Plan
+type: feat
+date: 2026-08-17
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Subagent Tool Card Status - Plan
+
+## Goal Capsule
+
+- **Objective:** Desktop tool card shows live and completed subagent progress in the TUI collapsed shape, without changing the subagent extension or spawning child sessions.
+- **Authority:** This plan's Product Contract, then `.scratch/fork-overlay/DECISIONS.md` overlay rule, then existing renderer event/tool-card patterns.
+- **Execution profile:** Three units. Pure trail model first, then event apply, then overlay hook + merge. Contract tests only.
+- **Stop:** Host does not actually emit `tool_execution_update` to the renderer, or completed `toolResult` drops `details`. Report and stop. Do not invent a new protocol.
+- **Tail:** Implementation owns local tests. No PR/release in this plan.
+
+## Product Contract
+
+### Summary
+
+Desktop already receives subagent `onUpdate` payloads and stores `details` on the final tool result.
+The renderer ignores updates and paints `running` until end, then only the final text.
+This plan makes the parent tool card consume those payloads: live collapsed trail while running, same trail after complete, expand for the full path.
+
+### Problem Frame
+
+A subagent is a separate `pi --mode json --no-session` process.
+The parent card is a black box for minutes.
+CLI TUI already renders live tool calls and usage from the same `details`.
+Telegram/Feishu adapters already map `tool_execution_update`.
+Desktop host forwards the event; `useAgentSession` has no case for it.
+`ToolCallBlock` treats missing `toolResult` as `running`.
+After complete, `details` sits unused except for edit diffs.
+
+### Requirements
+
+**Live card**
+
+- R1. While a subagent tool is running, the parent tool card shows a live collapsed trail instead of a bare `running` caret.
+- R2. The collapsed trail shows agent identity, live/done/fail mark, the last 5–10 child tool or text items, and usage when present.
+
+**After complete**
+
+- R3. After the tool ends, the same collapsed trail remains on the card.
+- R4. Expanding the card shows the full child item list and final output, not only the last 5–10 items.
+
+**Other tools**
+
+- R5. A non-subagent tool that emits `onUpdate` may show live `content` text.
+- R6. A non-subagent tool without a subagent-shaped `details` object keeps today's card (header + `running` or final text / diff).
+
+**Constraints**
+
+- R7. The subagent extension is not modified.
+- R8. Child pi processes do not appear as sidebar sessions.
+- R9. Proof is renderer contract tests with fixture events and `details` shapes, not a live child-pi e2e.
+
+### Key Decisions
+
+- Tool card is the live surface. `(session-settled: user-directed — chosen over status-bar widget and sidebar child session: watcher stays on the parent call)` Governs R1, R7, R8.
+- Live density is TUI collapsed equivalent. `(session-settled: user-directed — chosen over minimal HUD and full nested transcript: same mental model as CLI, enough to see the current tool)` Governs R2, R4.
+- Completed cards keep the trail. `(session-settled: user-directed — chosen over live-only then collapse to final answer: post-hoc review of what scout/worker did)` Governs R3, R4.
+- Verification stays on fixture contract tests. `(session-settled: user-directed — chosen over live child-pi e2e: cheaper and enough for this renderer gap)` Governs R9.
+
+### Actors
+
+- A1. Desktop user watching the parent session.
+
+### Key Flows
+
+- F1. Single subagent run
+  - **Trigger:** Parent model calls `subagent` with one agent.
+  - **Actors:** A1
+  - **Steps:** Assistant message commits with the tool call. Updates fill the card trail. Tool end freezes the same trail from stored `details`.
+  - **Covered by:** R1, R2, R3
+- F2. Parallel or chain
+  - **Trigger:** Parent calls `subagent` with `tasks` or `chain`.
+  - **Actors:** A1
+  - **Steps:** Card lists each child row. Parallel header can read `N/M done`. Expand shows every child's items.
+  - **Covered by:** R2, R4
+- F3. Reload a finished session
+  - **Trigger:** User opens a session that already has a subagent `toolResult` with `details`.
+  - **Actors:** A1
+  - **Steps:** Card renders the trail from stored `details`. No live map involved.
+  - **Covered by:** R3, R4
+- F4. Ordinary tool
+  - **Trigger:** `bash` / `read` / edit tool runs.
+  - **Actors:** A1
+  - **Steps:** Card stays today's UI unless that tool also sent a subagent-shaped `details`.
+  - **Covered by:** R5, R6
+
+### Acceptance Examples
+
+- AE1. Covers F1 / R1 / R2. Given a live `tool_execution_update` whose `details.mode` is `single` and `results[0]` has a `grep` tool call. When the parent card renders. Then the user sees the agent name, a live mark, and `grep` in the last items, not only `running`.
+- AE2. Covers F3 / R3 / R4. Given a history `toolResult` with subagent `details` and more than 10 child items. When the card is collapsed. Then only the last 5–10 items show. When expanded. Then all items and the final text show.
+- AE3. Covers F4 / R6. Given a running `bash` tool with no `details`. When the card renders. Then it still shows today's `running` caret.
+
+### Success Criteria
+
+- A1 can tell which child agent is running and which child tool last ran without leaving the parent card.
+- After reload, a completed subagent card still shows that path.
+- Ordinary tool cards do not change layout.
+
+### Scope Boundaries
+
+- In: Desktop renderer consumption of existing update + `details`.
+- Out: subagent extension edits, sidebar child sessions, status-bar widget as the primary surface, default full transcript, new host RPC, persist mid-run partials to jsonl.
+
+#### Deferred to Follow-Up Work
+
+- Dual-surface status-bar echo of the same trail.
+- Host-side fix if `tool_execution_update` is found not to reach the renderer (stop condition, not this plan's scope to invent).
+
+### Sources
+
+- Session grill that closed the Product Key Decisions.
+- Subagent `onUpdate` / `details` / TUI `renderResult` in the installed extension (live parallel uses `exitCode === -1`).
+- Host generic event emit in `src/agent-host/rpc-manager.ts`.
+- Channel `tool_execution_update` mapping in `src/agent-host/channels/pi-session-bridge.ts`.
+- Renderer ignore path: `src/renderer/hooks/useAgentSession.ts` (`tool_execution_start` / `end` only).
+- Card: `src/renderer/components/MessageView.tsx` `ToolCallBlock`.
+- Result index: `src/renderer/lib/tool-message-index.ts`.
+- Streaming bubble does not receive `toolResults`; live tools sit on the committed assistant message after `message_end`.
+- Overlay law: `.scratch/fork-overlay/DECISIONS.md`.
+
+---
+
+## Planning Contract
+
+Product Contract preservation: ce-plan-bootstrap, no upstream contract to preserve.
+
+### Key Technical Decisions
+
+- KTD1. **Overlay hook, not a MessageView rewrite.** Extra UI lives under `src/renderer/fork/`. Upstream `ToolCallBlock` / `ChatWindow` / `useAgentSession` only call thin hooks. Follows fork overlay law. Instantiates the tool-card Key Decision for R1.
+- KTD2. **Live vs final is store identity, not `exitCode`.** A result from the in-memory partial map is live. A history `toolResult` is final. Single-mode live payloads start at `exitCode: 0`, so `exitCode` cannot mark ⏳. Parallel already uses `-1` for running rows; the view-model may honor that inside a live payload. Instantiates R1, R2.
+- KTD3. **Merge partials as synthetic `toolResult`s.** `ChatWindow` unions the partial map into `toolResults` for the committed assistant message. `ToolCallBlock` then always has a `result` during live subagent work and does not need a third running state. Instantiates R1, R5.
+- KTD4. **Recognize subagent `details` by shape.** Require `mode` in `single | parallel | chain` and a `results` array. Do not key only on `toolName === "subagent"`. Missing or foreign `details` falls through to R5/R6. Instantiates R2, R6.
+- KTD5. **Partials are ephemeral.** Do not write `tool_execution_update` into session jsonl. Final trail comes from the real `toolResult.details` after `tool_execution_end`. Instantiates R3, R7.
+
+### High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Ext as Subagent extension
+  participant Host as Agent host
+  participant Sess as useAgentSession
+  participant Chat as ChatWindow
+  participant Card as ToolCallBlock
+
+  Ext->>Host: onUpdate content+details
+  Host->>Sess: tool_execution_update
+  Sess->>Sess: partials by toolCallId
+  Note over Chat: assistant already in history
+  Chat->>Card: toolResults union history+partials
+  Card->>Card: fork trail if details match KTD4
+  Host->>Sess: toolResult message_end + tool_execution_end
+  Sess->>Sess: drop partial id
+  Chat->>Card: history details only
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> Empty: tool_execution_start
+  Empty --> Live: first matching update
+  Live --> Live: later updates
+  Live --> Final: history toolResult
+  Empty --> Final: end with no updates
+  Final --> [*]
+```
+
+```mermaid
+flowchart TB
+  header[Existing tool header]
+  header --> body{details match KTD4?}
+  body -->|yes collapsed| trail[Last 5-10 items + usage]
+  body -->|yes expanded| full[All items + final text]
+  body -->|no + live content| text[Partial content text]
+  body -->|no + no result| running[Today running caret]
+  body -->|no + final| today[Today text or diff]
+```
+
+### Assumptions
+
+- Host `inner.subscribe` already forwards `tool_execution_update` to the renderer event stream.
+- Completed `toolResult` messages already persist `details` when the extension returns them.
+- U1/U2 fixture tests fail closed if either assumption is wrong; implementer stops per Goal Capsule.
+
+### Implementation Constraints
+
+- No new dependencies.
+- No feature flag, compat wrapper, or details-schema versioning.
+- New chrome strings go through existing `useI18n` if they are user-facing sentences. Icons and raw agent/tool names stay as data.
+- Overlay rebase surface stays hook-sized.
+
+### Sequencing
+
+U1 view-model → U2 event apply → U3 merge + hook.
+U3 needs both. Do not hook MessageView before the model can render a fixture.
+
+---
+
+## Implementation Units
+
+### U1. Subagent trail view-model
+
+**Goal:** Pure function turns unknown `details` plus live/final flag into collapsed and expanded trail rows.
+**Requirements:** R2, R4, R6
+**Dependencies:** none
+**Files:**
+
+- `src/renderer/fork/subagent-trail.ts`
+- `src/renderer/fork/subagent-trail.test.mjs`
+  **Approach:**
+
+1. Duck-type per KTD4. Return null for foreign details.
+2. Build per-result rows: agent, live/done/fail mark per KTD2, last 5–10 display items collapsed, all items expanded, usage string.
+3. Parallel/chain: one header line plus one row per child. Honor `exitCode === -1` as running inside a live payload.
+   **Patterns to follow:** `src/renderer/fork/usage.ts` (pure fork helper + sibling test). Item formatting can mirror the extension's `getDisplayItems` / `formatToolCall` idea without importing the extension.
+   **Execution note:** Test-first on fixtures: single live grep, parallel mixed -1/0, chain, foreign details, >10 items collapse.
+   **Test scenarios:**
+
+- Covers AE1. Single live details with one child `grep` → not null, live mark, `grep` in collapsed items.
+- Covers AE2. Final details with 12 text/tool items → collapsed length 10, expanded length 12, final text present when expanded.
+- Foreign `{ patch: "..." }` details → null.
+- Parallel live: one `exitCode === -1`, one `0` → header shows 1/2 done and the running row is live.
+- Empty `results` → still recognized if mode is valid; collapsed shows no items, not today's `running` decision (U3 owns that fallback).
+  **Verification:** `node scripts/test.mjs src/renderer/fork/subagent-trail.test.mjs`
+
+### U2. Apply tool_execution_update
+
+**Goal:** Renderer keeps an ephemeral partial result per `toolCallId` and drops it on end.
+**Requirements:** R1, R5, R9
+**Dependencies:** none
+**Files:**
+
+- `src/renderer/lib/tool-execution-partials.ts`
+- `src/renderer/lib/tool-execution-partials.test.mjs`
+- `src/renderer/hooks/useAgentSession.ts`
+  **Approach:**
+
+1. Pure apply/remove helpers for a `Map<toolCallId, ToolResultMessage>`.
+2. `tool_execution_update` upserts `{ role: "toolResult", toolCallId, toolName, content, details }` from `partialResult`.
+3. `tool_execution_end` and run reset delete that id.
+4. Return the partial map from `useAgentSession` so `ChatWindow` can merge it. Do not keep the map hook-local.
+5. Confirm the event type string the renderer actually receives before wiring. If it never arrives, stop.
+   **Patterns to follow:** Existing `handleAgentEvent` cases for `tool_execution_start` / `end`. Channel mapping in `src/agent-host/channels/pi-session-bridge.ts` for field names (`partialResult`).
+   **Execution note:** Characterize the apply helper first. Hook is a thin case.
+   **Test scenarios:**
+
+- Update then second update same id → map size 1, latest content/details win.
+- Update then end → map empty.
+- Update missing `toolCallId` → map unchanged.
+- `partialResult` with only `content` text (no details) → synthetic result still stored (R5).
+- Run reset / `agent_end` → map empty.
+  **Verification:** `node scripts/test.mjs src/renderer/lib/tool-execution-partials.test.mjs`
+
+### U3. Card hook and history merge
+
+**Goal:** Committed assistant tool cards render U1 trails from history or partials. Ordinary cards unchanged.
+**Requirements:** R1, R3, R4, R5, R6
+**Dependencies:** U1, U2
+**Files:**
+
+- `src/renderer/fork/SubagentTrail.tsx`
+- `src/renderer/fork/index.ts`
+- `src/renderer/components/MessageView.tsx`
+- `src/renderer/components/ChatWindow.tsx`
+- `src/renderer/components/message-view.test.mjs`
+  **Approach:**
+
+1. `ChatWindow` merges U2 partials into `toolResults` for history `MessageView`s. Streaming bubble stays as today (it has no tool results).
+2. `ToolCallBlock` calls a fork hook: if U1 returns a trail, render it in the result body; else keep today's `running` / text / diff.
+3. Expand uses the existing header toggle. Collapsed vs expanded is the existing `expanded` boolean.
+4. Keep hook call sites one-liners per KTD1.
+   **Patterns to follow:** `forkStatusBarStatuses` / `forkNoticeDurationMs` call sites. `message-view.test.mjs` `renderToStaticMarkup` + `importTestBundle`.
+   **Test scenarios:**
+
+- Covers AE1. Assistant + toolCall + synthetic live result with single-mode details → markup has agent name and child tool, not a lone `running`.
+- Covers AE2. Final `toolResult` with 12 items → collapsed omits early item text; expanded includes it.
+- Covers AE3. Running `bash` with no result → still contains `running`.
+- Edit tool with `details.patch` and no subagent shape → still a diff, not a trail.
+- History-only final subagent `details` (no partial map) → trail renders. Proves F3.
+  **Verification:** `node scripts/test.mjs src/renderer/components/message-view.test.mjs src/renderer/fork/subagent-trail.test.mjs`
+
+---
+
+## Verification Contract
+
+| Gate                         | Command                                                                   | Proves               |
+| ---------------------------- | ------------------------------------------------------------------------- | -------------------- |
+| U1                           | `node scripts/test.mjs src/renderer/fork/subagent-trail.test.mjs`         | R2, R4, R6 duck-type |
+| U2                           | `node scripts/test.mjs src/renderer/lib/tool-execution-partials.test.mjs` | R1, R5 apply/reset   |
+| U3                           | `node scripts/test.mjs src/renderer/components/message-view.test.mjs`     | AE1–AE3, F3          |
+| Types if public types change | `npm run typecheck`                                                       | hook signatures      |
+
+No `release:validate`. No browser/electron e2e. No live child pi.
+
+Before any extra check: name the live uncertainty it would settle. If the unit test already settled it, do not add another gate.
+
+---
+
+## Definition of Done
+
+- R1–R9 have a unit that cites them and a test scenario that can fail.
+- Overlay extras are in `src/renderer/fork/`. Upstream diffs are hook lines plus merge plumbing.
+- Subagent extension files are untouched.
+- Abandoned spikes deleted.
+- Stop condition honored if events or `details` persistence are missing.
+
+### Per-unit done
+
+- U1. Foreign details return null. Collapse/expand counts match AE2.
+- U2. Latest update wins. End/reset clears.
+- U3. AE1–AE3 markup tests pass. Bash card still shows `running`.

--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -93,6 +93,7 @@ interface Props {
   draftKey?: string;
   /** Session working directory — enables the @ file autocomplete menu */
   cwd?: string | null;
+  statusChips?: Array<{ key: string; text: string }>;
 }
 
 export interface ChatInputHandle {
@@ -261,6 +262,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
     onPromptWithStreamingBehavior,
     draftKey,
     cwd,
+    statusChips,
   }: Props,
   ref,
 ) {
@@ -2204,6 +2206,30 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
                   )}
               </div>
             )}
+            {(statusChips ?? [])
+              .filter((chip) => chip.text.trim().length > 0)
+              .map((chip) => (
+                <span
+                  key={chip.key}
+                  title={`${chip.key}: ${chip.text}`}
+                  style={{
+                    maxWidth: 220,
+                    padding: "4px 8px",
+                    borderRadius: 999,
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-panel)",
+                    color: "var(--text-muted)",
+                    fontSize: 11,
+                    lineHeight: "20px",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    flexShrink: 1,
+                  }}
+                >
+                  {chip.text}
+                </span>
+              ))}
           </div>
 
           {/* spacer */}

--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -500,7 +500,7 @@ export function ChatWindow({
       onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
       cwd={session?.cwd ?? newSessionCwd}
-      statusChips={extensionStatuses}
+      statusChips={extensionStatuses.filter((status) => /grok|usage/i.test(`${status.key} ${status.text}`))}
     />
   );
 

--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -500,6 +500,7 @@ export function ChatWindow({
       onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
       cwd={session?.cwd ?? newSessionCwd}
+      statusChips={extensionStatuses}
     />
   );
 
@@ -702,7 +703,9 @@ export function ChatWindow({
                       </button>
                     </div>
                   )}
-                  <ExtensionStatusBar statuses={extensionStatuses} />
+                  <ExtensionStatusBar
+                    statuses={extensionStatuses.filter((status) => !/grok|usage/i.test(status.key))}
+                  />
                   <ExtensionWidgets widgets={aboveEditorWidgets} />
 
                   {(() => {
@@ -1141,9 +1144,9 @@ function NoticeShelf({
               display: "flex",
               alignItems: "center",
               gap: 10,
-              minHeight: 60,
-              height: 60,
-              maxHeight: 60,
+              minHeight: 40,
+              maxHeight: 240,
+              alignItems: "flex-start" as const,
               marginBottom: index === notices.length - 1 ? 0 : 6,
               overflow: "hidden",
               borderRadius: 14,
@@ -1175,12 +1178,14 @@ function NoticeShelf({
             />
             <span
               style={{
-                padding: "14px 0",
+                padding: "10px 0",
                 minWidth: 0,
                 maxWidth: "100%",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
+                overflow: "auto",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                fontSize: 13,
+                lineHeight: 1.4,
               }}
             >
               {notice.message}

--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -25,8 +25,10 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 import { useObservedElementHeight } from "@/hooks/useObservedElementHeight";
 import type { SessionStatsInfo } from "@/lib/pi-types";
 import { MessageRenderKeyRegistry, type MessageRenderRole } from "@/lib/message-render-key";
+import { mergeToolResults } from "@/lib/tool-execution-partials";
 import { buildToolMessageIndex } from "@/lib/tool-message-index";
 import { useI18n } from "@/i18n";
+import { forkNoticeItemStyle, forkNoticeMessageStyle, forkStatusBarStatuses, forkUsageChips } from "@/fork";
 
 interface Props {
   session: SessionInfo | null;
@@ -315,6 +317,7 @@ export function ChatWindow({
     sendExtensionCustomInput,
     isAutoModelSelection,
     agentPhase,
+    toolPartials,
     isNew,
     messagesEndRef,
     liveContentEndRef,
@@ -500,7 +503,7 @@ export function ChatWindow({
       onAudioUnlock={unlockAudio}
       draftKey={session?.id ?? (newSessionCwd ? `new:${newSessionCwd}` : undefined)}
       cwd={session?.cwd ?? newSessionCwd}
-      statusChips={extensionStatuses.filter((status) => /grok|usage/i.test(`${status.key} ${status.text}`))}
+      statusChips={forkUsageChips(extensionStatuses)}
     />
   );
 
@@ -703,9 +706,7 @@ export function ChatWindow({
                       </button>
                     </div>
                   )}
-                  <ExtensionStatusBar
-                    statuses={extensionStatuses.filter((status) => !/grok|usage/i.test(status.key))}
-                  />
+                  <ExtensionStatusBar statuses={forkStatusBarStatuses(extensionStatuses)} />
                   <ExtensionWidgets widgets={aboveEditorWidgets} />
 
                   {(() => {
@@ -775,7 +776,7 @@ export function ChatWindow({
                         <SessionProfiler key={renderKey} id="MessageView">
                           <MessageView
                             message={msg}
-                            toolResults={toolData?.results}
+                            toolResults={mergeToolResults(toolData?.results, toolPartials)}
                             toolCallDurations={toolData?.durations}
                             modelNames={modelNames}
                             cwd={messageCwd}
@@ -1144,9 +1145,10 @@ function NoticeShelf({
               display: "flex",
               alignItems: "center",
               gap: 10,
-              minHeight: 40,
-              maxHeight: 240,
-              alignItems: "flex-start" as const,
+              minHeight: 60,
+              height: 60,
+              maxHeight: 60,
+              ...forkNoticeItemStyle(),
               marginBottom: index === notices.length - 1 ? 0 : 6,
               overflow: "hidden",
               borderRadius: 14,
@@ -1178,14 +1180,13 @@ function NoticeShelf({
             />
             <span
               style={{
-                padding: "10px 0",
+                padding: "14px 0",
                 minWidth: 0,
                 maxWidth: "100%",
-                overflow: "auto",
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                fontSize: 13,
-                lineHeight: 1.4,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                ...forkNoticeMessageStyle(),
               }}
             >
               {notice.message}

--- a/src/renderer/components/MessageView.tsx
+++ b/src/renderer/components/MessageView.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/lib/message-display";
 import { getUserBubbleStyle } from "@/lib/channel-message-style";
 import { CHANNEL_ATTACHMENT_PROMPT_PLACEHOLDER, channelAttachmentCopyText } from "@shared/channel-message";
+import { SubagentTrailView } from "@/fork/SubagentTrail";
+import { parseSubagentTrail } from "@/fork/subagent-trail";
 import { useI18n } from "@/i18n";
 import { useTheme } from "@/hooks/useTheme";
 import { parseUnifiedPatch, type SplitDiffCell } from "@/lib/patch";
@@ -995,6 +997,7 @@ function ToolCallBlock({
   const inputStr = JSON.stringify(block.input, null, 2);
   const isEditTool = isEditToolName(block.toolName);
   const resultDiff = result && !result.isError ? getResultDiff(result) : null;
+  const subagentTrail = result ? parseSubagentTrail(result.details, result.timestamp === undefined) : null;
 
   // Result display
   const resultText = result
@@ -1094,7 +1097,10 @@ function ToolCallBlock({
       )}
 
       {/* ── Paired result — always show summary; expand for full detail ── */}
-      {result &&
+      {subagentTrail ? (
+        <SubagentTrailView trail={subagentTrail} expanded={expanded} />
+      ) : (
+        result &&
         (resultDiff ? (
           expanded ? (
             <PairedDiffResult diff={resultDiff} />
@@ -1120,7 +1126,8 @@ function ToolCallBlock({
             isError={isError}
             collapsed={!expanded}
           />
-        ))}
+        ))
+      )}
       {result && <DeferredContentActions content={result.content} onLoad={onLoadDeferredContent} />}
       {browserTabId && (
         <button

--- a/src/renderer/components/message-view.test.mjs
+++ b/src/renderer/components/message-view.test.mjs
@@ -110,6 +110,123 @@ test("continues to hide a completed empty non-error assistant message", () => {
   assert.equal(renderToStaticMarkup(createElement(MessageView, { message: assistant() })), "");
 });
 
+function toolCallMessage(toolName, toolCallId = "call-1") {
+  return assistant({
+    content: [{ type: "toolCall", toolCallId, toolName, input: { agent: "scout", task: "find auth" } }],
+  });
+}
+
+function textItems(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    role: "assistant",
+    content: [{ type: "text", text: `item-${i + 1}` }],
+  }));
+}
+
+test("live subagent details show agent and child tool instead of running", () => {
+  const html = renderToStaticMarkup(
+    createElement(MessageView, {
+      message: toolCallMessage("subagent"),
+      toolResults: new Map([
+        [
+          "call-1",
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            content: [{ type: "text", text: "(running...)" }],
+            details: {
+              mode: "single",
+              results: [
+                {
+                  agent: "scout",
+                  exitCode: 0,
+                  messages: [
+                    {
+                      role: "assistant",
+                      content: [{ type: "toolCall", name: "grep", arguments: { pattern: "auth" } }],
+                    },
+                  ],
+                  usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+                },
+              ],
+            },
+          },
+        ],
+      ]),
+    }),
+  );
+
+  assert.match(html, /scout/);
+  assert.match(html, /grep/);
+  assert.doesNotMatch(html, />running</);
+});
+
+test("final subagent details keep a collapsed trail from history", () => {
+  const html = renderToStaticMarkup(
+    createElement(MessageView, {
+      message: toolCallMessage("subagent"),
+      toolResults: new Map([
+        [
+          "call-1",
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            timestamp: 2_000,
+            content: [{ type: "text", text: "done" }],
+            details: {
+              mode: "single",
+              results: [
+                {
+                  agent: "scout",
+                  exitCode: 0,
+                  messages: textItems(12),
+                  usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+                },
+              ],
+            },
+          },
+        ],
+      ]),
+    }),
+  );
+
+  assert.match(html, /item-12/);
+  assert.doesNotMatch(html, /item-1</);
+});
+
+test("running bash without details still shows running", () => {
+  const html = renderToStaticMarkup(
+    createElement(MessageView, {
+      message: toolCallMessage("bash"),
+    }),
+  );
+
+  assert.match(html, /running/);
+});
+
+test("edit details without subagent shape still render as a diff", () => {
+  const html = renderToStaticMarkup(
+    createElement(MessageView, {
+      message: toolCallMessage("edit"),
+      toolResults: new Map([
+        [
+          "call-1",
+          {
+            role: "toolResult",
+            toolCallId: "call-1",
+            timestamp: 2_000,
+            content: [{ type: "text", text: "ok" }],
+            details: { patch: "diff --git a/file b/file\n+hello" },
+          },
+        ],
+      ]),
+    }),
+  );
+
+  assert.match(html, /\+hello/);
+  assert.doesNotMatch(html, /data-testid="subagent-trail"/);
+});
+
 test("renders compaction summaries collapsed by default", () => {
   const html = renderToStaticMarkup(
     createElement(MessageView, {

--- a/src/renderer/fork/SubagentTrail.tsx
+++ b/src/renderer/fork/SubagentTrail.tsx
@@ -1,0 +1,54 @@
+import type { CSSProperties } from "react";
+import type { ToolResultMessage } from "@/lib/types";
+import { parseSubagentTrail, type SubagentTrail, type TrailItem, type TrailMark } from "./subagent-trail";
+
+const bodyStyle: CSSProperties = {
+  padding: "8px 12px",
+  color: "var(--tool-fg)",
+  fontSize: 12,
+  lineHeight: 1.5,
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+};
+
+const muted: CSSProperties = { color: "var(--text-dim)" };
+
+export function ForkSubagentTrail({ result, expanded }: { result: ToolResultMessage; expanded: boolean }) {
+  const trail = parseSubagentTrail(result.details, result.timestamp === undefined);
+  if (!trail) return null;
+  return <SubagentTrailView trail={trail} expanded={expanded} />;
+}
+
+export function SubagentTrailView({ trail, expanded }: { trail: SubagentTrail; expanded: boolean }) {
+  return (
+    <div data-testid="subagent-trail" style={bodyStyle}>
+      {trail.header && <div style={{ fontWeight: 600 }}>{`${markGlyph(trail.mark)} ${trail.header}`}</div>}
+      {trail.rows.map((row, index) => {
+        const items = expanded ? row.items : row.collapsedItems;
+        return (
+          <div key={`${row.agent}-${row.step ?? index}`} style={{ marginTop: trail.header || index > 0 ? 8 : 0 }}>
+            <div style={{ fontWeight: 600 }}>{`${markGlyph(row.mark)} ${row.agent}`}</div>
+            {row.errorMessage && <div style={{ color: "var(--danger)" }}>{row.errorMessage}</div>}
+            {items.map((item, itemIndex) => (
+              <div key={itemIndex} style={muted}>
+                {formatItem(item)}
+              </div>
+            ))}
+            {row.usage && <div style={muted}>{row.usage}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function markGlyph(mark: TrailMark): string {
+  if (mark === "live") return "⏳";
+  if (mark === "fail") return "✗";
+  return "✓";
+}
+
+function formatItem(item: TrailItem): string {
+  if (item.type === "toolCall") return item.preview ? `→ ${item.name} ${item.preview}` : `→ ${item.name}`;
+  return item.text;
+}

--- a/src/renderer/fork/SubagentTrail.tsx
+++ b/src/renderer/fork/SubagentTrail.tsx
@@ -1,6 +1,5 @@
 import type { CSSProperties } from "react";
-import type { ToolResultMessage } from "@/lib/types";
-import { parseSubagentTrail, type SubagentTrail, type TrailItem, type TrailMark } from "./subagent-trail";
+import { type SubagentTrail, type TrailItem, type TrailMark } from "./subagent-trail";
 
 const bodyStyle: CSSProperties = {
   padding: "8px 12px",
@@ -12,12 +11,6 @@ const bodyStyle: CSSProperties = {
 };
 
 const muted: CSSProperties = { color: "var(--text-dim)" };
-
-export function ForkSubagentTrail({ result, expanded }: { result: ToolResultMessage; expanded: boolean }) {
-  const trail = parseSubagentTrail(result.details, result.timestamp === undefined);
-  if (!trail) return null;
-  return <SubagentTrailView trail={trail} expanded={expanded} />;
-}
 
 export function SubagentTrailView({ trail, expanded }: { trail: SubagentTrail; expanded: boolean }) {
   return (

--- a/src/renderer/fork/subagent-trail.test.mjs
+++ b/src/renderer/fork/subagent-trail.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseSubagentTrail } from "./subagent-trail.ts";
+
+function assistantItems(items) {
+  return [
+    {
+      role: "assistant",
+      content: items.map((item) =>
+        item.type === "toolCall"
+          ? { type: "toolCall", name: item.name, arguments: item.args ?? {} }
+          : { type: "text", text: item.text },
+      ),
+    },
+  ];
+}
+
+function result(overrides = {}) {
+  return {
+    agent: "scout",
+    agentSource: "user",
+    task: "find auth",
+    exitCode: 0,
+    messages: [],
+    stderr: "",
+    usage: { input: 10, output: 4, cacheRead: 0, cacheWrite: 0, cost: 0, turns: 1 },
+    ...overrides,
+  };
+}
+
+test("single live details with grep is a live trail", () => {
+  const trail = parseSubagentTrail(
+    {
+      mode: "single",
+      results: [
+        result({
+          messages: assistantItems([{ type: "toolCall", name: "grep", args: { pattern: "auth" } }]),
+        }),
+      ],
+    },
+    true,
+  );
+
+  assert.ok(trail);
+  assert.equal(trail.mode, "single");
+  assert.equal(trail.live, true);
+  assert.equal(trail.mark, "live");
+  assert.equal(trail.rows[0].agent, "scout");
+  assert.equal(trail.rows[0].mark, "live");
+  assert.equal(trail.rows[0].collapsedItems[0].type, "toolCall");
+  assert.equal(trail.rows[0].collapsedItems[0].name, "grep");
+});
+
+test("final details with 12 items collapse to last 10", () => {
+  const items = Array.from({ length: 12 }, (_, i) => ({ type: "text", text: `item-${i + 1}` }));
+  const trail = parseSubagentTrail(
+    {
+      mode: "single",
+      results: [
+        result({
+          messages: assistantItems(items),
+        }),
+      ],
+    },
+    false,
+  );
+
+  assert.ok(trail);
+  assert.equal(trail.live, false);
+  assert.equal(trail.mark, "done");
+  assert.equal(trail.rows[0].items.length, 12);
+  assert.equal(trail.rows[0].collapsedItems.length, 10);
+  assert.equal(trail.rows[0].collapsedItems[0].text, "item-3");
+  assert.equal(trail.rows[0].collapsedItems.at(-1).text, "item-12");
+  assert.equal(trail.rows[0].finalText, "item-12");
+});
+
+test("foreign patch details return null", () => {
+  assert.equal(parseSubagentTrail({ patch: "diff --git a b" }, false), null);
+});
+
+test("parallel live honors exitCode -1", () => {
+  const trail = parseSubagentTrail(
+    {
+      mode: "parallel",
+      results: [
+        result({ agent: "scout", exitCode: -1, messages: assistantItems([{ type: "toolCall", name: "read" }]) }),
+        result({ agent: "planner", exitCode: 0, messages: assistantItems([{ type: "text", text: "plan ready" }]) }),
+      ],
+    },
+    true,
+  );
+
+  assert.ok(trail);
+  assert.equal(trail.header, "1/2 done, 1 running");
+  assert.equal(trail.mark, "live");
+  assert.equal(trail.rows[0].mark, "live");
+  assert.equal(trail.rows[1].mark, "done");
+});
+
+test("valid mode with empty results still parses", () => {
+  const trail = parseSubagentTrail({ mode: "chain", results: [] }, true);
+  assert.ok(trail);
+  assert.equal(trail.mode, "chain");
+  assert.deepEqual(trail.rows, []);
+});

--- a/src/renderer/fork/subagent-trail.ts
+++ b/src/renderer/fork/subagent-trail.ts
@@ -1,0 +1,156 @@
+const MODES = new Set(["single", "parallel", "chain"]);
+const COLLAPSED_ITEM_COUNT = 10;
+
+export type TrailMark = "live" | "done" | "fail";
+
+export type TrailItem = { type: "text"; text: string } | { type: "toolCall"; name: string; preview: string };
+
+export type TrailRow = {
+  agent: string;
+  mark: TrailMark;
+  step?: number;
+  items: TrailItem[];
+  collapsedItems: TrailItem[];
+  usage?: string;
+  finalText?: string;
+  errorMessage?: string;
+};
+
+export type SubagentTrail = {
+  mode: "single" | "parallel" | "chain";
+  live: boolean;
+  mark: TrailMark;
+  header?: string;
+  rows: TrailRow[];
+};
+
+export function parseSubagentTrail(details: unknown, live: boolean): SubagentTrail | null {
+  if (!isRecord(details)) return null;
+  const mode = details.mode;
+  if (typeof mode !== "string" || !MODES.has(mode)) return null;
+  if (!Array.isArray(details.results)) return null;
+
+  const rows = details.results.map((entry) => parseRow(entry, mode, live));
+  const header = mode === "single" ? undefined : formatHeader(mode, rows, live);
+  return {
+    mode: mode as SubagentTrail["mode"],
+    live,
+    mark: aggregateMark(rows, live),
+    header,
+    rows,
+  };
+}
+
+function parseRow(entry: unknown, mode: string, live: boolean): TrailRow {
+  const record = isRecord(entry) ? entry : {};
+  const items = getDisplayItems(record.messages);
+  const failed = isFailedResult(record);
+  const agent = typeof record.agent === "string" && record.agent ? record.agent : "unknown";
+  const usage = formatUsage(record.usage, typeof record.model === "string" ? record.model : undefined);
+  return {
+    agent,
+    mark: rowMark(mode, record, live, failed),
+    step: typeof record.step === "number" ? record.step : undefined,
+    items,
+    collapsedItems: items.slice(-COLLAPSED_ITEM_COUNT),
+    usage,
+    finalText: lastText(items),
+    errorMessage: typeof record.errorMessage === "string" ? record.errorMessage : undefined,
+  };
+}
+
+function rowMark(mode: string, record: Record<string, unknown>, live: boolean, failed: boolean): TrailMark {
+  if (failed) return "fail";
+  if (!live) return "done";
+  if (record.exitCode === -1) return "live";
+  // Single-mode live updates keep exitCode 0 until the process closes.
+  if (mode === "single") return "live";
+  return "done";
+}
+
+function aggregateMark(rows: TrailRow[], live: boolean): TrailMark {
+  if (live && rows.some((row) => row.mark === "live")) return "live";
+  if (rows.some((row) => row.mark === "fail")) return "fail";
+  if (rows.length === 0 && live) return "live";
+  return "done";
+}
+
+function formatHeader(mode: string, rows: TrailRow[], live: boolean): string | undefined {
+  if (rows.length === 0) return undefined;
+  const running = rows.filter((row) => row.mark === "live").length;
+  const done = rows.length - running;
+  if (live && running > 0) return `${done}/${rows.length} done, ${running} running`;
+  if (mode === "chain") return `${done}/${rows.length} steps`;
+  return `${done}/${rows.length} tasks`;
+}
+
+function isFailedResult(record: Record<string, unknown>): boolean {
+  const exitCode = record.exitCode;
+  if (typeof exitCode === "number" && exitCode !== 0 && exitCode !== -1) return true;
+  return record.stopReason === "error" || record.stopReason === "aborted";
+}
+
+function getDisplayItems(messages: unknown): TrailItem[] {
+  if (!Array.isArray(messages)) return [];
+  const items: TrailItem[] = [];
+  for (const message of messages) {
+    if (!isRecord(message) || message.role !== "assistant" || !Array.isArray(message.content)) continue;
+    for (const part of message.content) {
+      if (!isRecord(part)) continue;
+      if (part.type === "text" && typeof part.text === "string") {
+        items.push({ type: "text", text: part.text });
+        continue;
+      }
+      if (part.type === "toolCall") {
+        const name =
+          (typeof part.name === "string" && part.name) ||
+          (typeof part.toolName === "string" && part.toolName) ||
+          "tool";
+        const args = isRecord(part.arguments) ? part.arguments : isRecord(part.input) ? part.input : {};
+        items.push({ type: "toolCall", name, preview: previewArgs(args) });
+      }
+    }
+  }
+  return items;
+}
+
+function lastText(items: TrailItem[]): string | undefined {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (item.type === "text" && item.text.trim()) return item.text;
+  }
+  return undefined;
+}
+
+function formatUsage(usage: unknown, model?: string): string | undefined {
+  if (!isRecord(usage)) return undefined;
+  const parts: string[] = [];
+  if (typeof usage.turns === "number" && usage.turns) parts.push(`${usage.turns} turn${usage.turns > 1 ? "s" : ""}`);
+  if (typeof usage.input === "number" && usage.input) parts.push(`↑${formatTokens(usage.input)}`);
+  if (typeof usage.output === "number" && usage.output) parts.push(`↓${formatTokens(usage.output)}`);
+  if (typeof usage.cacheRead === "number" && usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
+  if (typeof usage.cacheWrite === "number" && usage.cacheWrite) parts.push(`W${formatTokens(usage.cacheWrite)}`);
+  if (typeof usage.cost === "number" && usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
+  if (model) parts.push(model);
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+function formatTokens(count: number): string {
+  if (count < 1000) return count.toString();
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1000000) return `${Math.round(count / 1000)}k`;
+  return `${(count / 1000000).toFixed(1)}M`;
+}
+
+function previewArgs(args: Record<string, unknown>): string {
+  if (typeof args.command === "string") return args.command.slice(0, 80);
+  if (typeof args.pattern === "string") return args.pattern.slice(0, 80);
+  if (typeof args.path === "string") return args.path.slice(0, 80);
+  if (typeof args.file_path === "string") return args.file_path.slice(0, 80);
+  const first = Object.values(args)[0];
+  return first === undefined ? "" : String(first).slice(0, 80);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/renderer/hooks/useAgentSession.ts
+++ b/src/renderer/hooks/useAgentSession.ts
@@ -9,6 +9,7 @@ import type {
   SessionInfo,
   SessionTreeNode,
   TextContent,
+  ToolResultMessage,
 } from "@/lib/types";
 import type { ModelCatalogStatus, ModelsListResult, SessionDetail, SessionRuntimeState } from "@contract/types";
 import { normalizeToolCalls } from "@/lib/normalize";
@@ -28,6 +29,11 @@ import {
 } from "@/lib/api-client";
 import { getToolNamesForPreset, type ToolEntry } from "@/lib/tool-presets";
 import type { SessionStatsInfo } from "@/lib/pi-types";
+import {
+  applyToolExecutionUpdate,
+  clearAllToolExecutionPartials,
+  clearToolExecutionPartial,
+} from "@/lib/tool-execution-partials";
 import { subscribeActiveSessionLiveSync } from "./active-session-live-sync";
 import { isNearChatBottom, shouldDisengageScrollMagnet, shouldStopChatAutoFollow } from "./chat-scroll-policy";
 
@@ -63,7 +69,8 @@ import {
   replaceLastHistoryMessage,
   type SessionHistoryValue,
 } from "@/lib/session-history-update";
-import { NOTICE_VISIBLE_MS, noticeExpiryDelay, noticeReducer, type NoticeType } from "@/lib/notice-queue";
+import { noticeExpiryDelay, noticeReducer, type NoticeType } from "@/lib/notice-queue";
+import { forkNoticeDurationMs } from "@/fork";
 import { useI18n } from "@/i18n";
 import { sessionClientErrorMessage } from "@/lib/session-error-message";
 
@@ -340,6 +347,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const [compactError, setCompactError] = useState<string | null>(null);
   const [compactResult, setCompactResult] = useState<CompactResultInfo | null>(null);
   const [agentPhase, setAgentPhase] = useState<AgentPhase>(null);
+  const [toolPartials, setToolPartials] = useState<ReadonlyMap<string, ToolResultMessage>>(() => new Map());
   const [slashCommands, setSlashCommands] = useState<SlashCommandInfo[]>([]);
   const [slashCommandsLoading, setSlashCommandsLoading] = useState(false);
   const [noticeState, dispatchNotice] = useReducer(noticeReducer, { visible: [], pending: [] });
@@ -363,6 +371,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const modelListSizeRef = useRef(0);
   const sessionIdRef = useRef<string | null>(session?.id ?? null);
   const agentRunningRef = useRef(false);
+  const abortRequestedRef = useRef(false);
   const handleAgentEventRef = useRef<((event: AgentEvent) => void) | null>(null);
   const initialScrollDoneRef = useRef(false);
   const lastUserMsgRef = useRef<HTMLDivElement | null>(null);
@@ -848,14 +857,13 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const addNotice = useCallback((notice: { id?: string; message: string; type?: NoticeType }) => {
     const message = notice.message.trim();
     if (!message) return;
-    const multiline = message.includes("\n") || message.length > 80;
     dispatchNotice({
       type: "add",
       notice: {
         id: notice.id ?? createNoticeId(),
         message,
         type: notice.type ?? "info",
-        expiresAt: Date.now() + (multiline ? NOTICE_VISIBLE_MS * 4 : NOTICE_VISIBLE_MS),
+        expiresAt: Date.now() + forkNoticeDurationMs(message),
       },
     });
   }, []);
@@ -1045,12 +1053,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           externalTurnAutoFollowRef.current = false;
           break;
         case "agent_start":
+          if (abortRequestedRef.current) break;
           agentRunningRef.current = true;
           setAgentRunning(true);
           setAgentPhase({ kind: "waiting_model" });
           dispatch({ type: "start" });
           break;
         case "agent_end":
+          abortRequestedRef.current = false;
           // A late agent_end can arrive over the stream after reconcileAgentState
           // already finished this run — don't re-trigger completion.
           if (!agentRunningRef.current) break;
@@ -1058,6 +1068,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           setAgentRunning(false);
           setAgentPhase(null);
           setRetryInfo(null);
+          setToolPartials(clearAllToolExecutionPartials());
           dispatch({ type: "end" });
           if (sessionIdRef.current) {
             void loadSession(sessionIdRef.current);
@@ -1136,6 +1147,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           break;
         }
         case "tool_execution_start": {
+          if (!agentRunningRef.current) break;
           const id = event.toolCallId as string;
           const name = event.toolName as string;
           setAgentPhase((prev) => {
@@ -1145,8 +1157,15 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           });
           break;
         }
+        case "tool_execution_update": {
+          if (!agentRunningRef.current) break;
+          setToolPartials((prev) => applyToolExecutionUpdate(prev, event));
+          break;
+        }
         case "tool_execution_end": {
+          if (!agentRunningRef.current) break;
           const id = event.toolCallId as string;
+          setToolPartials((prev) => clearToolExecutionPartial(prev, id));
           setAgentPhase((prev) => {
             if (prev?.kind !== "running_tools") return prev;
             const tools = prev.tools.filter((t) => t.id !== id);
@@ -1202,6 +1221,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
       const trimmedMessage = message.trim();
       if (!trimmedMessage && !images?.length) return;
       if (agentRunning) return;
+      abortRequestedRef.current = false;
       const isSlashCommandPrompt = !images?.length && trimmedMessage.startsWith("/");
       const promptRunId = promptRunIdRef.current + 1;
 
@@ -1228,12 +1248,27 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
 
       const piImages = images?.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
 
+      const throwIfSendAborted = async (sid: string | null) => {
+        if (!abortRequestedRef.current) return;
+        if (sid) {
+          try {
+            await sendAgentCommand(sid, { type: "abort" });
+          } catch (error) {
+            console.error("Failed to abort:", error);
+          }
+        }
+        const error = new Error("Aborted");
+        error.name = "AbortError";
+        throw error;
+      };
+
       try {
         let sentSessionId: string | null = null;
         if (isNew && newSessionCwd) {
           const selectedModel = newSessionModel;
           const existingSid = sessionIdRef.current ?? (await ensuringNewSessionRef.current);
           const sid = existingSid ?? (await ensureNewSession());
+          await throwIfSendAborted(sid);
 
           if (sid) {
             sentSessionId = sid;
@@ -1245,9 +1280,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
                   provider: selectedModel.provider,
                   modelId: selectedModel.modelId,
                 });
+                await throwIfSendAborted(sid);
               }
             }
             await ensureEventsConnected(sid);
+            await throwIfSendAborted(sid);
             await sendAgentCommand(sid, {
               type: "prompt",
               message,
@@ -1257,7 +1294,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           }
         } else if (session) {
           sentSessionId = session.id;
+          await throwIfSendAborted(session.id);
           await ensureEventsConnected(session.id);
+          await throwIfSendAborted(session.id);
           await sendAgentCommand(session.id, {
             type: "prompt",
             message,
@@ -1268,7 +1307,8 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
           void waitForPromptSettlement(sentSessionId, promptRunId);
         }
       } catch (e) {
-        console.error("Failed to send message:", e);
+        const aborted = e instanceof Error && e.name === "AbortError";
+        if (!aborted) console.error("Failed to send message:", e);
         const optimisticKey = optimisticUserMessageKeyRef.current;
         if (optimisticKey) {
           updateHistory((current) => {
@@ -1278,10 +1318,12 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
               : current;
           });
         }
-        addNotice({
-          type: "error",
-          message: sessionClientErrorMessage(e, t, t("messageSendFailed", "Failed to send message.")),
-        });
+        if (!aborted) {
+          addNotice({
+            type: "error",
+            message: sessionClientErrorMessage(e, t, t("messageSendFailed", "Failed to send message.")),
+          });
+        }
         optimisticUserMessageKeyRef.current = null;
         agentRunningRef.current = false;
         setAgentRunning(false);
@@ -1307,14 +1349,24 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     ],
   );
 
-  const handleAbort = useCallback(async () => {
-    const sid = sessionIdRef.current;
-    if (!sid) return;
-    try {
-      await sendAgentCommand(sid, { type: "abort" });
-    } catch (e) {
-      console.error("Failed to abort:", e);
+  const handleAbort = useCallback(() => {
+    abortRequestedRef.current = true;
+    if (agentRunningRef.current) {
+      agentRunningRef.current = false;
+      setAgentRunning(false);
+      setAgentPhase(null);
+      setRetryInfo(null);
+      dispatch({ type: "end" });
     }
+    void (async () => {
+      const sid = sessionIdRef.current ?? (await ensuringNewSessionRef.current);
+      if (!sid) return;
+      try {
+        await sendAgentCommand(sid, { type: "abort" });
+      } catch (e) {
+        console.error("Failed to abort:", e);
+      }
+    })();
   }, []);
 
   const handleFork = useCallback(
@@ -2173,6 +2225,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     sendExtensionCustomInput,
     isAutoModelSelection: isNew && newSessionModel === null,
     agentPhase,
+    toolPartials,
     isNew,
     // "Scroll to bottom" affordance state + action
     isAwayFromBottom,

--- a/src/renderer/hooks/useAgentSession.ts
+++ b/src/renderer/hooks/useAgentSession.ts
@@ -848,13 +848,14 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const addNotice = useCallback((notice: { id?: string; message: string; type?: NoticeType }) => {
     const message = notice.message.trim();
     if (!message) return;
+    const multiline = message.includes("\n") || message.length > 80;
     dispatchNotice({
       type: "add",
       notice: {
         id: notice.id ?? createNoticeId(),
         message,
         type: notice.type ?? "info",
-        expiresAt: Date.now() + NOTICE_VISIBLE_MS,
+        expiresAt: Date.now() + (multiline ? NOTICE_VISIBLE_MS * 4 : NOTICE_VISIBLE_MS),
       },
     });
   }, []);

--- a/src/renderer/lib/tool-execution-partials.test.mjs
+++ b/src/renderer/lib/tool-execution-partials.test.mjs
@@ -5,6 +5,7 @@ import {
   applyToolExecutionUpdate,
   clearAllToolExecutionPartials,
   clearToolExecutionPartial,
+  mergeToolResults,
 } from "./tool-execution-partials.ts";
 
 test("second update same id keeps latest content and details", () => {
@@ -67,4 +68,17 @@ test("run reset empties the map", () => {
   });
   assert.equal(clearAllToolExecutionPartials().size, 0);
   assert.equal(filled.size, 1);
+});
+
+test("merge prefers history over a live partial", () => {
+  const history = new Map([
+    ["call-1", { role: "toolResult", toolCallId: "call-1", content: [{ type: "text", text: "final" }] }],
+  ]);
+  const partials = new Map([
+    ["call-1", { role: "toolResult", toolCallId: "call-1", content: [{ type: "text", text: "live" }] }],
+    ["call-2", { role: "toolResult", toolCallId: "call-2", content: [{ type: "text", text: "other" }] }],
+  ]);
+  const merged = mergeToolResults(history, partials);
+  assert.equal(merged.get("call-1").content[0].text, "final");
+  assert.equal(merged.get("call-2").content[0].text, "other");
 });

--- a/src/renderer/lib/tool-execution-partials.test.mjs
+++ b/src/renderer/lib/tool-execution-partials.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyToolExecutionUpdate,
+  clearAllToolExecutionPartials,
+  clearToolExecutionPartial,
+} from "./tool-execution-partials.ts";
+
+test("second update same id keeps latest content and details", () => {
+  const first = applyToolExecutionUpdate(new Map(), {
+    toolCallId: "call-1",
+    toolName: "subagent",
+    partialResult: { content: [{ type: "text", text: "old" }], details: { mode: "single", results: [] } },
+  });
+  const second = applyToolExecutionUpdate(first, {
+    toolCallId: "call-1",
+    toolName: "subagent",
+    partialResult: {
+      content: [{ type: "text", text: "new" }],
+      details: { mode: "single", results: [{ agent: "scout" }] },
+    },
+  });
+
+  assert.equal(second.size, 1);
+  const result = second.get("call-1");
+  assert.equal(result.content[0].text, "new");
+  assert.equal(result.details.results[0].agent, "scout");
+});
+
+test("end removes that id", () => {
+  const filled = applyToolExecutionUpdate(new Map(), {
+    toolCallId: "call-1",
+    toolName: "subagent",
+    partialResult: { content: [{ type: "text", text: "x" }] },
+  });
+  const cleared = clearToolExecutionPartial(filled, "call-1");
+  assert.equal(cleared.size, 0);
+});
+
+test("update without toolCallId leaves the map unchanged", () => {
+  const current = applyToolExecutionUpdate(new Map(), {
+    toolCallId: "keep",
+    partialResult: { content: [{ type: "text", text: "x" }] },
+  });
+  const next = applyToolExecutionUpdate(current, { partialResult: { content: [{ type: "text", text: "y" }] } });
+  assert.equal(next.size, 1);
+  assert.equal(next.get("keep").content[0].text, "x");
+});
+
+test("content-only partial is still stored", () => {
+  const next = applyToolExecutionUpdate(new Map(), {
+    toolCallId: "bash-1",
+    toolName: "bash",
+    partialResult: { content: [{ type: "text", text: "hello" }] },
+  });
+  const result = next.get("bash-1");
+  assert.equal(result.toolName, "bash");
+  assert.equal(result.content[0].text, "hello");
+  assert.equal(result.details, undefined);
+});
+
+test("run reset empties the map", () => {
+  const filled = applyToolExecutionUpdate(new Map(), {
+    toolCallId: "call-1",
+    partialResult: { content: [{ type: "text", text: "x" }] },
+  });
+  assert.equal(clearAllToolExecutionPartials().size, 0);
+  assert.equal(filled.size, 1);
+});

--- a/src/renderer/lib/tool-execution-partials.ts
+++ b/src/renderer/lib/tool-execution-partials.ts
@@ -29,6 +29,18 @@ export function clearAllToolExecutionPartials(): Map<string, ToolResultMessage> 
   return new Map();
 }
 
+export function mergeToolResults(
+  history: ReadonlyMap<string, ToolResultMessage> | undefined,
+  partials: ReadonlyMap<string, ToolResultMessage> | undefined,
+): ReadonlyMap<string, ToolResultMessage> | undefined {
+  if (!partials || partials.size === 0) return history;
+  const next = new Map(history);
+  for (const [id, partial] of partials) {
+    if (!next.has(id)) next.set(id, partial);
+  }
+  return next;
+}
+
 function extractContent(partialResult: unknown): TextContent[] {
   if (!isRecord(partialResult) || !Array.isArray(partialResult.content)) return [];
   return partialResult.content.filter(

--- a/src/renderer/lib/tool-execution-partials.ts
+++ b/src/renderer/lib/tool-execution-partials.ts
@@ -1,0 +1,41 @@
+import type { TextContent, ToolResultMessage } from "./types";
+
+export function applyToolExecutionUpdate(
+  current: ReadonlyMap<string, ToolResultMessage>,
+  event: { toolCallId?: unknown; toolName?: unknown; partialResult?: unknown },
+): Map<string, ToolResultMessage> {
+  const next = new Map(current);
+  if (typeof event.toolCallId !== "string" || event.toolCallId.length === 0) return next;
+  next.set(event.toolCallId, {
+    role: "toolResult",
+    toolCallId: event.toolCallId,
+    toolName: typeof event.toolName === "string" ? event.toolName : undefined,
+    content: extractContent(event.partialResult),
+    details: isRecord(event.partialResult) ? event.partialResult.details : undefined,
+  });
+  return next;
+}
+
+export function clearToolExecutionPartial(
+  current: ReadonlyMap<string, ToolResultMessage>,
+  toolCallId: unknown,
+): Map<string, ToolResultMessage> {
+  const next = new Map(current);
+  if (typeof toolCallId === "string") next.delete(toolCallId);
+  return next;
+}
+
+export function clearAllToolExecutionPartials(): Map<string, ToolResultMessage> {
+  return new Map();
+}
+
+function extractContent(partialResult: unknown): TextContent[] {
+  if (!isRecord(partialResult) || !Array.isArray(partialResult.content)) return [];
+  return partialResult.content.filter(
+    (block): block is TextContent => isRecord(block) && block.type === "text" && typeof block.text === "string",
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

A running subagent used to look like a dead `running` caret. The parent card now shows who is working, the last child tools or text, and usage while the call is open, and that trail stays after it finishes so you can expand and see the path.

Scrolling away from a live turn also used to lose the tail for good. A bottom badge snaps back and keeps following until you scroll away again.

This branch also carries the 0.1.9 scroll-magnet / version bump that is not yet on `origin/main`.

Session-settled decisions carried from planning: tool card (user-directed, over status-bar widget and sidebar child session); TUI collapsed density (user-directed, over HUD and full transcript); keep trail after complete (user-directed, over live-only); contract tests not child-pi e2e (user-directed).

## Validation

Focused renderer tests cover live single-agent details, a 12-item history collapse, parallel `exitCode === -1` rows, foreign edit diffs, and bash still showing `running` (23 pass). No live child-pi was run in the Desktop GUI. Full `node scripts/test.mjs` still fails a pre-existing Weixin User-Agent expect of `PiDesktop/0.1.0`.
