### PR TITLE
fix(chat): preserve multiline notice content

### DIFF
--- a/src/renderer/components/ChatWindow.tsx
+++ b/src/renderer/components/ChatWindow.tsx
@@ -1090,8 +1090,6 @@ function NoticeShelf({
               alignItems: "center",
               gap: 10,
               minHeight: 60,
-              height: 60,
-              maxHeight: 60,
               marginBottom: index === notices.length - 1 ? 0 : 6,
               overflow: "hidden",
               borderRadius: 14,
@@ -1126,9 +1124,8 @@ function NoticeShelf({
                 padding: "14px 0",
                 minWidth: 0,
                 maxWidth: "100%",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
+                overflowWrap: "anywhere",
+                whiteSpace: "pre-wrap",
               }}
             >
               {notice.message}

--- a/src/renderer/components/notice-shelf-layout.test.mjs
+++ b/src/renderer/components/notice-shelf-layout.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chatWindowSource = readFileSync(new URL("./ChatWindow.tsx", import.meta.url), "utf8");
+const cssSource = readFileSync(new URL("../globals.css", import.meta.url), "utf8");
+
+const noticeShelfStart = chatWindowSource.indexOf("function NoticeShelf(");
+const noticeShelfEnd = chatWindowSource.indexOf("type ExtensionDialogRequest", noticeShelfStart);
+assert.notEqual(noticeShelfStart, -1);
+assert.notEqual(noticeShelfEnd, -1);
+const noticeShelfSource = chatWindowSource.slice(noticeShelfStart, noticeShelfEnd);
+
+const noticeItemClass = noticeShelfSource.indexOf('className="notice-shelf-item"');
+const noticeItemStyleStart = noticeShelfSource.indexOf("style={{", noticeItemClass);
+const noticeItemStyleEnd = noticeShelfSource.indexOf("}}", noticeItemStyleStart);
+const noticeMessage = noticeShelfSource.indexOf("{notice.message}");
+const noticeMessageStyleStart = noticeShelfSource.lastIndexOf("style={{", noticeMessage);
+const noticeMessageStyleEnd = noticeShelfSource.indexOf("}}", noticeMessageStyleStart);
+for (const position of [
+  noticeItemClass,
+  noticeItemStyleStart,
+  noticeItemStyleEnd,
+  noticeMessage,
+  noticeMessageStyleStart,
+  noticeMessageStyleEnd,
+]) {
+  assert.notEqual(position, -1);
+}
+const noticeItemStyle = noticeShelfSource.slice(noticeItemStyleStart, noticeItemStyleEnd);
+const noticeMessageStyle = noticeShelfSource.slice(noticeMessageStyleStart, noticeMessageStyleEnd);
+
+function keyframesSource(name, nextMarker) {
+  const start = cssSource.indexOf(`@keyframes ${name}`);
+  const end = cssSource.indexOf(nextMarker, start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  return cssSource.slice(start, end);
+}
+
+test("multiline notices preserve explicit line breaks", () => {
+  assert.match(noticeMessageStyle, /whiteSpace:\s*"pre-wrap"/);
+  assert.doesNotMatch(noticeMessageStyle, /whiteSpace:\s*"nowrap"/);
+});
+
+test("long unbroken notice text wraps instead of being truncated", () => {
+  assert.match(noticeMessageStyle, /overflowWrap:\s*"anywhere"/);
+  assert.doesNotMatch(noticeMessageStyle, /textOverflow:\s*"ellipsis"/);
+});
+
+test("single-line notices keep their baseline height without capping taller content", () => {
+  assert.match(noticeItemStyle, /minHeight:\s*60/);
+  assert.doesNotMatch(noticeItemStyle, /(?:^|\n)\s*height:\s*60/);
+  assert.doesNotMatch(noticeItemStyle, /maxHeight:\s*60/);
+});
+
+test("notice animations never restore a fixed height", () => {
+  const animations = [
+    keyframesSource("notice-shelf-in", "@keyframes notice-shelf-out"),
+    keyframesSource("notice-shelf-out", "@media (prefers-reduced-motion: reduce)"),
+  ];
+
+  for (const animation of animations) {
+    assert.doesNotMatch(animation, /(?:^|\n)\s*(?:height|min-height|max-height):/);
+    assert.match(animation, /opacity:/);
+    assert.match(animation, /transform:/);
+  }
+});

--- a/src/renderer/globals.css
+++ b/src/renderer/globals.css
@@ -919,17 +919,11 @@ span.linenumber {
 @keyframes notice-shelf-in {
   from {
     opacity: 0;
-    height: 0;
-    max-height: 0;
-    min-height: 0;
     margin-bottom: 0;
     transform: translateY(-6px) scale(0.995);
   }
   to {
     opacity: 1;
-    height: 60px;
-    max-height: 60px;
-    min-height: 60px;
     transform: translateY(0) scale(1);
   }
 }
@@ -937,16 +931,10 @@ span.linenumber {
 @keyframes notice-shelf-out {
   from {
     opacity: 1;
-    height: 60px;
-    max-height: 60px;
-    min-height: 60px;
     transform: translateY(0) scale(1);
   }
   to {
     opacity: 0;
-    height: 0;
-    max-height: 0;
-    min-height: 0;
     margin-bottom: 0;
     transform: translateY(-5px) scale(0.995);
   }


### PR DESCRIPTION
Fixes DLYZZT/pi-desktop#30

## Problem

`NoticeShelf` fixed every notice at 60px, rendered the message with `nowrap` and ellipsis, and repeated the 60px cap in its enter and exit keyframes. Multiline messages were therefore collapsed into one clipped line, and the entry animation's `both` fill mode kept that cap after the animation completed.

## Fix

- Keep the existing 60px minimum for single-line notices while allowing each notice to grow with its content.
- Preserve explicit line breaks with `white-space: pre-wrap` and wrap long unbroken text with `overflow-wrap: anywhere`.
- Remove height declarations from both notice animations so their fill modes cannot reapply a fixed height.
- Add regression coverage for multiline text, single-line minimum height, long words, and animation keyframes.

## Verification

- `npm run verify`
- Notice layout regression tests: 4/4; the original implementation failed all four before the fix.
