### PR TITLE
fix(composer): compress screenshots so draft image cache fits

### DIFF
--- a/src/renderer/lib/image-file-processing.test.mjs
+++ b/src/renderer/lib/image-file-processing.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 
-import { processImageFileBatch } from "./image-file-processing.ts";
+import { DRAFT_IMAGE_TARGET_BYTES, compressDraftImage, processImageFileBatch } from "./image-file-processing.ts";
 
 function file(name) {
   return { name, type: "image/png" };
@@ -43,6 +43,31 @@ test("malformed reader output revokes every unusable preview", async () => {
   assert.equal(result.images.length, 0);
   assert.equal(result.failures.length, 2);
   assert.deepEqual(revoked.sort(), ["blob:one", "blob:two"]);
+});
+
+test("compressDraftImage leaves small images unchanged without canvas APIs", async () => {
+  const small = { data: "YQ==", mimeType: "image/png" };
+  assert.deepEqual(await compressDraftImage(small), small);
+
+  const large = {
+    data: "A".repeat(Math.ceil(((DRAFT_IMAGE_TARGET_BYTES + 1) * 4) / 3)),
+    mimeType: "image/png",
+  };
+  assert.deepEqual(await compressDraftImage(large), large);
+});
+
+test("oversized screenshots are compressed before they enter the draft", async () => {
+  const files = [file("shot")];
+  const payload = "A".repeat(Math.ceil(((DRAFT_IMAGE_TARGET_BYTES + 1) * 4) / 3));
+  const result = await processImageFileBatch(files, {
+    readAsDataUrl: async () => `data:image/png;base64,${payload}`,
+    createObjectUrl: (item) => `blob:${item.name}`,
+    revokeObjectUrl() {},
+    compressImage: async () => ({ data: "YQ==", mimeType: "image/jpeg" }),
+  });
+
+  assert.equal(result.failures.length, 0);
+  assert.deepEqual(result.images, [{ data: "YQ==", mimeType: "image/jpeg", previewUrl: "blob:shot" }]);
 });
 
 test("ChatInput preserves successes, reports failures, and owns pending previews", () => {

--- a/src/renderer/lib/image-file-processing.ts
+++ b/src/renderer/lib/image-file-processing.ts
@@ -1,3 +1,5 @@
+import { decodedBase64ByteLength } from "../../shared/draft-store.ts";
+
 export interface ProcessedImageFile {
   data: string;
   mimeType: string;
@@ -9,10 +11,14 @@ export interface ImageFileFailure {
   error: unknown;
 }
 
+export const DRAFT_IMAGE_MAX_DIMENSION = 2048;
+export const DRAFT_IMAGE_TARGET_BYTES = 512 * 1024;
+
 interface ImageFileProcessingDependencies {
   readAsDataUrl: (file: File) => Promise<string>;
   createObjectUrl: (file: File) => string;
   revokeObjectUrl: (url: string) => void;
+  compressImage?: (image: { data: string; mimeType: string }) => Promise<{ data: string; mimeType: string }>;
 }
 
 const browserDependencies: ImageFileProcessingDependencies = {
@@ -27,12 +33,139 @@ const browserDependencies: ImageFileProcessingDependencies = {
   },
   createObjectUrl: (file) => URL.createObjectURL(file),
   revokeObjectUrl: (url) => URL.revokeObjectURL(url),
+  compressImage: compressDraftImage,
 };
+
+function base64ToBytes(data: string): Uint8Array {
+  if (typeof atob === "function") {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+  return Uint8Array.from(Buffer.from(data, "base64"));
+}
+
+function isAnimatedOrVector(mimeType: string): boolean {
+  const mime = mimeType.toLowerCase();
+  return mime.includes("gif") || mime.includes("svg") || mime.includes("xml");
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  if (typeof FileReader !== "function") return Buffer.from(buffer).toString("base64");
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result ?? "");
+      const separator = result.indexOf(",");
+      resolve(separator >= 0 ? result.slice(separator + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to encode compressed image"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+type Draft2DContext = Pick<CanvasRenderingContext2D, "fillStyle" | "fillRect" | "drawImage">;
+
+function createDraftCanvas(width: number, height: number): OffscreenCanvas | HTMLCanvasElement | null {
+  if (typeof OffscreenCanvas === "function") return new OffscreenCanvas(width, height);
+  if (typeof document === "undefined" || typeof document.createElement !== "function") return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+function getDraft2dContext(canvas: OffscreenCanvas | HTMLCanvasElement): Draft2DContext | null {
+  const ctx = canvas.getContext("2d");
+  if (!ctx || !("drawImage" in ctx) || !("fillRect" in ctx) || !("fillStyle" in ctx)) return null;
+  return ctx;
+}
+
+async function canvasToBlob(
+  canvas: OffscreenCanvas | HTMLCanvasElement,
+  mimeType: string,
+  quality: number,
+): Promise<Blob | null> {
+  if ("convertToBlob" in canvas && typeof canvas.convertToBlob === "function") {
+    return canvas.convertToBlob({ type: mimeType, quality });
+  }
+  if (!("toBlob" in canvas) || typeof canvas.toBlob !== "function") return null;
+  return new Promise((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), mimeType, quality);
+  });
+}
+
+/**
+ * Downscale and JPEG-compress large screenshots so they fit the composer draft
+ * cache. No-ops for small images, animated/vector formats, or environments
+ * without canvas APIs (unit tests).
+ */
+export async function compressDraftImage(image: {
+  data: string;
+  mimeType: string;
+}): Promise<{ data: string; mimeType: string }> {
+  const mimeType = image.mimeType || "image/png";
+  const originalBytes = decodedBase64ByteLength(image.data);
+  if (originalBytes <= DRAFT_IMAGE_TARGET_BYTES) return image;
+  if (isAnimatedOrVector(mimeType)) return image;
+  if (typeof createImageBitmap !== "function") return image;
+
+  let bitmap: ImageBitmap;
+  try {
+    const bytes = new Uint8Array(base64ToBytes(image.data));
+    bitmap = await createImageBitmap(new Blob([bytes], { type: mimeType }));
+  } catch {
+    return image;
+  }
+
+  try {
+    const maxEdge = Math.max(bitmap.width, bitmap.height, 1);
+    let width = bitmap.width;
+    let height = bitmap.height;
+    if (maxEdge > DRAFT_IMAGE_MAX_DIMENSION) {
+      const scale = DRAFT_IMAGE_MAX_DIMENSION / maxEdge;
+      width = Math.max(1, Math.round(bitmap.width * scale));
+      height = Math.max(1, Math.round(bitmap.height * scale));
+    }
+
+    let best = image;
+    let bestBytes = originalBytes;
+    const sizes = [
+      { width, height },
+      { width: Math.max(1, Math.round(width * 0.75)), height: Math.max(1, Math.round(height * 0.75)) },
+    ];
+
+    for (const size of sizes) {
+      const canvas = createDraftCanvas(size.width, size.height);
+      if (!canvas) return best;
+      const ctx = getDraft2dContext(canvas);
+      if (!ctx) return best;
+      ctx.fillStyle = "#fff";
+      ctx.fillRect(0, 0, size.width, size.height);
+      ctx.drawImage(bitmap, 0, 0, size.width, size.height);
+      for (const quality of [0.84, 0.72, 0.6]) {
+        const blob = await canvasToBlob(canvas, "image/jpeg", quality);
+        if (!blob || blob.size >= bestBytes) continue;
+        best = { data: await blobToBase64(blob), mimeType: "image/jpeg" };
+        bestBytes = blob.size;
+        if (bestBytes <= DRAFT_IMAGE_TARGET_BYTES) return best;
+      }
+    }
+    return best;
+  } catch {
+    return image;
+  } finally {
+    bitmap.close();
+  }
+}
 
 export async function processImageFileBatch(
   files: File[],
   dependencies: ImageFileProcessingDependencies = browserDependencies,
 ): Promise<{ images: ProcessedImageFile[]; failures: ImageFileFailure[] }> {
+  const compressImage = dependencies.compressImage ?? compressDraftImage;
   const settled = await Promise.allSettled(
     files.map(async (file) => {
       const previewUrl = dependencies.createObjectUrl(file);
@@ -40,9 +173,13 @@ export async function processImageFileBatch(
         const dataUrl = await dependencies.readAsDataUrl(file);
         const separator = dataUrl.indexOf(",");
         if (separator < 0) throw new Error("Image reader returned an invalid data URL");
-        return {
+        const compressed = await compressImage({
           data: dataUrl.slice(separator + 1),
-          mimeType: file.type,
+          mimeType: file.type || "image/png",
+        });
+        return {
+          data: compressed.data,
+          mimeType: compressed.mimeType,
           previewUrl,
         } satisfies ProcessedImageFile;
       } catch (error) {

--- a/src/shared/draft-store.test.mjs
+++ b/src/shared/draft-store.test.mjs
@@ -5,6 +5,7 @@ import {
   CHAT_DRAFT_SCHEMA_VERSION,
   DraftPersistenceController,
   MAX_PERSISTED_DRAFT_FILES,
+  MAX_PERSISTED_DRAFT_IMAGE_BYTES,
   clearDraft,
   decodedBase64ByteLength,
   flushDraft,
@@ -44,7 +45,8 @@ test("base64 size accounting excludes oversized image sets before serialization"
   assert.equal(decodedBase64ByteLength("YQ=="), 1);
   assert.equal(decodedBase64ByteLength("YWI="), 2);
   assert.deepEqual(persistableDraftImages([{ data: "YQ==", mimeType: "image/png" }]).length, 1);
-  assert.deepEqual(persistableDraftImages([{ data: "A".repeat(3_000_000), mimeType: "image/png" }]), []);
+  const oversized = "A".repeat(Math.ceil(((MAX_PERSISTED_DRAFT_IMAGE_BYTES + 1) * 4) / 3));
+  assert.deepEqual(persistableDraftImages([{ data: oversized, mimeType: "image/png" }]), []);
 });
 
 test("image additions are rejected with distinct count and byte-limit reasons", () => {
@@ -56,10 +58,8 @@ test("image additions are rejected with distinct count and byte-limit reasons", 
   assert.deepEqual(countSelection.accepted, []);
   assert.equal(countSelection.rejected[0].reason, "count");
 
-  const byteSelection = selectDraftImageAdditions(
-    [],
-    [{ data: "A".repeat(2_100_000), mimeType: "image/png" }, tiny("small")],
-  );
+  const oversized = "A".repeat(Math.ceil(((MAX_PERSISTED_DRAFT_IMAGE_BYTES + 1) * 4) / 3));
+  const byteSelection = selectDraftImageAdditions([], [{ data: oversized, mimeType: "image/png" }, tiny("small")]);
   assert.deepEqual(byteSelection.accepted, [tiny("small")]);
   assert.equal(byteSelection.rejected[0].reason, "bytes");
 });

--- a/src/shared/draft-store.ts
+++ b/src/shared/draft-store.ts
@@ -27,7 +27,10 @@ const LS_PREFIX = "pi-desktop-draft:";
 export const CHAT_DRAFT_SCHEMA_VERSION = 2;
 export const MAX_PERSISTED_DRAFT_IMAGES = 4;
 export const MAX_PERSISTED_DRAFT_FILES = 8;
-export const MAX_PERSISTED_DRAFT_IMAGE_BYTES = 1.5 * 1024 * 1024;
+// Decoded image bytes stored in localStorage. Electron's quota is typically ~10MB;
+// 4MB decoded (~5.3MB JSON) leaves headroom for text drafts and other keys.
+// Attachments are compressed first so typical retina / screenshot-tool PNGs fit.
+export const MAX_PERSISTED_DRAFT_IMAGE_BYTES = 4 * 1024 * 1024;
 export const MAX_DRAFT_FILE_NAME_CHARS = 512;
 export const MAX_DRAFT_FILE_PATH_CHARS = 32_768;
 


### PR DESCRIPTION
## Problem

Composer drafts persist attached images in `localStorage` with a **1.5MB decoded** budget (max 4 images). macOS retina captures and tools like PixPin routinely produce **2–8MB PNGs**, so pasting or dropping a single screenshot fails with:

> The total image size exceeds the 1.5 MB draft limit.

Raising the cap alone is not enough: Electron `localStorage` is typically ~10MB, and raw PNG base64 would blow that quota.

## Fix

1. **Compress oversized attachments before they enter the draft** (`processImageFileBatch`):
   - Skip images already ≤ 512KB
   - Downscale longest edge to 2048px
   - Re-encode as JPEG (quality 0.84 → 0.72 → 0.6), shrinking further if needed
   - Keep the original when compression is larger, fails, or the format is GIF/SVG
2. **Raise `MAX_PERSISTED_DRAFT_IMAGE_BYTES` from 1.5MB to 4MB** decoded (~5.3MB JSON), leaving headroom under the ~10MB quota so a few compressed screenshots still persist.

Paste, drag-and-drop, and file picker all go through the same batch processor.

## Tests

- Draft byte-limit tests now use `MAX_PERSISTED_DRAFT_IMAGE_BYTES` instead of hardcoded 1.5MB payloads
- Image processing tests cover: small images unchanged without canvas APIs, injected compression for oversized screenshots, existing failure isolation

## Notes

This changes what is **sent to the model** as well as what is cached (the draft `data` is the payload). That matches Pi’s existing 2000×2000 auto-resize on the agent side and is enough for UI screenshots.