### PR TITLE
feat(chat): render mermaid diagrams by default after streaming

### DIFF
--- a/src/renderer/components/MarkdownBody.tsx
+++ b/src/renderer/components/MarkdownBody.tsx
@@ -295,7 +295,7 @@ function normalizeDisplayMath(markdown: string): string {
 
 function MermaidBlock({ code, isStreaming }: { code: string; isStreaming?: boolean }) {
   const { isDark } = useTheme();
-  const [showPreview, setShowPreview] = useState(false);
+  const [showPreview, setShowPreview] = useState(true);
   const [svg, setSvg] = useState<string | null>(null);
   const [renderedKey, setRenderedKey] = useState("");
   const [failedKey, setFailedKey] = useState<string | null>(null);


### PR DESCRIPTION
## Why
Mermaid fences in chat currently stay as a source block until Preview is clicked. That extra click makes diagrams easy to miss.

## Change
Default `MermaidBlock` to preview after the assistant turn finishes. Streaming still shows source (incomplete diagrams are skipped). The Source button remains.

## Test
1. Ask the agent for a mermaid flowchart.
2. While streaming, the fence stays as source.
3. After the turn ends, the diagram renders without clicking Preview.
4. Click Source to see the fence again.
